### PR TITLE
feat(ci): add SPA PR validation workflow

### DIFF
--- a/.github/workflows/spa-pr-validation.yml
+++ b/.github/workflows/spa-pr-validation.yml
@@ -1,0 +1,782 @@
+name: SPA PR Validation
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+run-name: "PR #${{ github.event.pull_request.number }} - Skills Test Validation"
+
+concurrency:
+  group: pr-validation-skills-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  # ============================================================
+  # GATE: Detect what changed, decide what to build/test
+  # ============================================================
+  gate:
+    if: github.event.label.name == 'run-tests'
+    runs-on: ubuntu-22.04
+    environment: iblai.app
+    outputs:
+      should-build-app: ${{ steps.decide.outputs.should-build-app }}
+      nodes-json: ${{ steps.config.outputs.nodes-json }}
+      venv-name: ${{ steps.config.outputs.venv-name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            app:
+              - 'src/**'
+              - 'app/**'
+              - 'components/**'
+              - 'features/**'
+              - 'hooks/**'
+              - 'lib/**'
+              - 'actions/**'
+              - 'contexts/**'
+              - 'public/**'
+              - 'next.config.*'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig*.json'
+              - 'tailwind.config.*'
+              - 'Dockerfile'
+            tests:
+              - 'tests/**'
+
+      - name: Decide build strategy
+        id: decide
+        run: |
+          APP_CHANGED="${{ steps.changes.outputs.app }}"
+
+          if [[ "$APP_CHANGED" == "true" && "${{ vars.ENABLE_TESTING }}" != "true" ]]; then
+            echo "should-build-app=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-build-app=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo ""
+          echo "=== Decision Summary ==="
+          echo "App code changed: $APP_CHANGED"
+          echo "ENABLE_TESTING: ${{ vars.ENABLE_TESTING }}"
+          echo "Build app image: $(if [[ "$APP_CHANGED" == "true" && "${{ vars.ENABLE_TESTING }}" != "true" ]]; then echo true; else echo false; fi)"
+
+      - name: Output config
+        id: config
+        run: |
+          echo "nodes-json<<EOF" >> $GITHUB_OUTPUT
+          echo '${{ vars.NODES }}' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "venv-name=${{ vars.IBL_CLI_VENV_NAME }}" >> $GITHUB_OUTPUT
+
+  # ============================================================
+  # TEST RESUMPTION CHECK
+  # ============================================================
+  check-resumption:
+    needs: [gate]
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-test-resumption.yml@main
+    with:
+      app-name: skills
+      pr-number: ${{ github.event.pull_request.number }}
+      test-dir: tests
+    secrets:
+      s3-bucket: ${{ secrets.S3_LOGS_BUCKET }}
+      aws-access-key-id: ${{ secrets.S3_LOGS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.S3_LOGS_SECRET_ACCESS_KEY }}
+      aws-region: ${{ vars.AWS_REGION }}
+
+  # ============================================================
+  # DOMAIN LOCK
+  # ============================================================
+  acquire-domain:
+    needs: [gate]
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-domain-lock.yml@main
+    with:
+      action: acquire
+      app-type: testing
+      context: "PR #${{ github.event.pull_request.number }} - Skills Testing"
+      allowed-domains: '3'
+      max-wait: 18000
+
+  # ============================================================
+  # VERIFICATION (parallel after domain lock)
+  # ============================================================
+  lint:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-linting.yml@main
+    secrets: inherit
+
+  typecheck:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-typecheck.yml@main
+    secrets: inherit
+
+  coverage:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-unit-test-coverage.yml@main
+    with:
+      coverage-threshold: 95
+    secrets: inherit
+
+  claude-review-quality:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-claude-review-quality.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  claude-review-uiux:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-claude-review-uiux.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  # ============================================================
+  # CHECK PRODUCTION VERSIONS (fallback images when not building)
+  # ============================================================
+  check-prod-versions:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    runs-on: image-deploy-ops-new
+    environment: iblai.app
+    outputs:
+      skills-uri: ${{ steps.read-skills.outputs.image-uri }}
+      auth-uri: ${{ steps.read-auth.outputs.image-uri }}
+    steps:
+      - name: Checkout ops
+        uses: actions/checkout@v4
+        with:
+          repository: iblai/ibl-web-ops
+          token: ${{ secrets.GIT_TOKEN || github.token }}
+          path: .ops
+
+      - name: Setup SSH
+        uses: ./.ops/.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+      - name: Read skills version from prod
+        id: read-skills
+        uses: ./.ops/.github/actions/read-prod-versions
+        with:
+          app-name: skills
+          nodes-json: ${{ vars.NODES_SPA_CHECK }}
+
+      - name: Read auth version from prod
+        id: read-auth
+        uses: ./.ops/.github/actions/read-prod-versions
+        with:
+          app-name: auth
+          nodes-json: ${{ vars.NODES_SPA_CHECK }}
+
+  # ============================================================
+  # BUILD DOCKER IMAGES
+  # ============================================================
+  build-app-image:
+    needs: [gate, acquire-domain]
+    if: >-
+      always() &&
+      needs.acquire-domain.result == 'success' &&
+      needs.gate.outputs.should-build-app == 'true'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-pr-docker-build.yml@main
+    secrets: inherit
+    with:
+      dockerfile-path: Dockerfile
+      image-name: ibl-skills-spa-pro
+      registry-type: ecr
+      event-name: pull_request
+      pr-number: ${{ github.event.pull_request.number }}
+
+  build-playwright-image:
+    needs: [gate, acquire-domain]
+    if: always() && needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-pr-docker-build.yml@main
+    secrets: inherit
+    with:
+      dockerfile-path: tests/Dockerfile
+      build-context: tests/
+      image-name: ibl-skills-playwright
+      registry-type: ocir
+      event-name: pull_request
+      pr-number: ${{ github.event.pull_request.number }}
+
+  # ============================================================
+  # DEPLOY SKILLS APP
+  # ============================================================
+  deploy-app:
+    needs: [gate, acquire-domain, lint, typecheck, build-app-image, check-prod-versions]
+    if: >-
+      always() &&
+      needs.acquire-domain.result == 'success' &&
+      needs.lint.result == 'success' &&
+      needs.typecheck.result == 'success' &&
+      needs.build-app-image.result != 'failure'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-spa-deployment.yml@main
+    with:
+      app-name: SKILLS
+      image-uri: ${{ vars.ENABLE_TESTING == 'true' && vars.SKILLS_IMAGE || needs.build-app-image.outputs.image-uri || needs.check-prod-versions.outputs.skills-uri }}
+      deployment-path: /ibl/app/ibl-spa/skills3
+      nodes-json: ${{ needs.gate.outputs.nodes-json }}
+      venv-name: ${{ needs.gate.outputs.venv-name }}
+    secrets:
+      ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+  # ============================================================
+  # DEPLOY AUTH (uses prod auth image)
+  # ============================================================
+  deploy-auth:
+    needs: [gate, acquire-domain, check-prod-versions, deploy-app]
+    if: always() && needs.acquire-domain.result == 'success' && needs.deploy-app.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-spa-deployment.yml@main
+    with:
+      app-name: AUTH
+      image-uri: ${{ needs.check-prod-versions.outputs.auth-uri }}
+      deployment-path: /ibl/app/ibl-spa/auth3
+      nodes-json: ${{ needs.gate.outputs.nodes-json }}
+      venv-name: ${{ needs.gate.outputs.venv-name }}
+    secrets:
+      ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+  # ============================================================
+  # SEQUENTIAL BROWSER TESTS (default mode)
+  # chrome -> health -> firefox -> health -> safari -> health -> edge
+  # ============================================================
+
+  # --- Chrome ---
+  verify-chrome:
+    needs: [gate, acquire-domain, deploy-auth, build-app-image, check-prod-versions]
+    if: always() && needs.deploy-auth.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-pre-test-health-check.yml@main
+    with:
+      app-name: SKILLS
+      expected-image-uri: ${{ vars.ENABLE_TESTING == 'true' && vars.SKILLS_IMAGE || needs.build-app-image.outputs.image-uri || needs.check-prod-versions.outputs.skills-uri }}
+      deployment-path: /ibl/app/ibl-spa/skills3
+      nodes-json: ${{ needs.gate.outputs.nodes-json }}
+      venv-name: ${{ needs.gate.outputs.venv-name }}
+      health-port: '5023'
+    secrets:
+      ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+  test-chrome:
+    needs: [gate, check-resumption, acquire-domain, deploy-auth, build-playwright-image, verify-chrome]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      needs.verify-chrome.result == 'success' &&
+      needs.check-resumption.outputs.chrome-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-chrome
+      browsers: 'chrome'
+      test-files: ${{ needs.check-resumption.outputs.chrome-test-files }}
+      workers: '3'
+
+  # --- Firefox ---
+  verify-firefox:
+    needs: [gate, acquire-domain, build-app-image, check-prod-versions, test-chrome]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      (needs.test-chrome.result == 'success' || needs.test-chrome.result == 'skipped')
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-pre-test-health-check.yml@main
+    with:
+      app-name: SKILLS
+      expected-image-uri: ${{ vars.ENABLE_TESTING == 'true' && vars.SKILLS_IMAGE || needs.build-app-image.outputs.image-uri || needs.check-prod-versions.outputs.skills-uri }}
+      deployment-path: /ibl/app/ibl-spa/skills3
+      nodes-json: ${{ needs.gate.outputs.nodes-json }}
+      venv-name: ${{ needs.gate.outputs.venv-name }}
+      health-port: '5023'
+    secrets:
+      ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+  test-firefox:
+    needs: [gate, check-resumption, acquire-domain, build-playwright-image, verify-firefox]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      needs.verify-firefox.result == 'success' &&
+      needs.check-resumption.outputs.firefox-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-firefox
+      browsers: 'firefox'
+      test-files: ${{ needs.check-resumption.outputs.firefox-test-files }}
+      workers: '3'
+
+  # --- Safari ---
+  verify-safari:
+    needs: [gate, acquire-domain, build-app-image, check-prod-versions, test-firefox]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      (needs.test-firefox.result == 'success' || needs.test-firefox.result == 'skipped')
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-pre-test-health-check.yml@main
+    with:
+      app-name: SKILLS
+      expected-image-uri: ${{ vars.ENABLE_TESTING == 'true' && vars.SKILLS_IMAGE || needs.build-app-image.outputs.image-uri || needs.check-prod-versions.outputs.skills-uri }}
+      deployment-path: /ibl/app/ibl-spa/skills3
+      nodes-json: ${{ needs.gate.outputs.nodes-json }}
+      venv-name: ${{ needs.gate.outputs.venv-name }}
+      health-port: '5023'
+    secrets:
+      ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+  test-safari:
+    needs: [gate, check-resumption, acquire-domain, build-playwright-image, verify-safari]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      needs.verify-safari.result == 'success' &&
+      needs.check-resumption.outputs.safari-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-safari
+      browsers: 'safari'
+      test-files: ${{ needs.check-resumption.outputs.safari-test-files }}
+      workers: '3'
+
+  # --- Edge ---
+  verify-edge:
+    needs: [gate, acquire-domain, build-app-image, check-prod-versions, test-safari]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      (needs.test-safari.result == 'success' || needs.test-safari.result == 'skipped')
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-pre-test-health-check.yml@main
+    with:
+      app-name: SKILLS
+      expected-image-uri: ${{ vars.ENABLE_TESTING == 'true' && vars.SKILLS_IMAGE || needs.build-app-image.outputs.image-uri || needs.check-prod-versions.outputs.skills-uri }}
+      deployment-path: /ibl/app/ibl-spa/skills3
+      nodes-json: ${{ needs.gate.outputs.nodes-json }}
+      venv-name: ${{ needs.gate.outputs.venv-name }}
+      health-port: '5023'
+    secrets:
+      ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+
+  test-edge:
+    needs: [gate, check-resumption, acquire-domain, build-playwright-image, verify-edge]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE != 'parallel-browsers' &&
+      needs.verify-edge.result == 'success' &&
+      needs.check-resumption.outputs.edge-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-edge
+      browsers: 'edge'
+      test-files: ${{ needs.check-resumption.outputs.edge-test-files }}
+      workers: '3'
+
+  # ============================================================
+  # PARALLEL BROWSER TESTS (when EXECUTION_MODE == 'parallel-browsers')
+  # ============================================================
+  test-chrome-parallel:
+    needs: [gate, check-resumption, acquire-domain, deploy-auth, build-playwright-image, verify-chrome]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE == 'parallel-browsers' &&
+      needs.verify-chrome.result == 'success' &&
+      needs.check-resumption.outputs.chrome-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-chrome
+      browsers: 'chrome'
+      test-files: ${{ needs.check-resumption.outputs.chrome-test-files }}
+      workers: '3'
+
+  test-firefox-parallel:
+    needs: [gate, check-resumption, acquire-domain, deploy-auth, build-playwright-image, verify-chrome]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE == 'parallel-browsers' &&
+      needs.verify-chrome.result == 'success' &&
+      needs.check-resumption.outputs.firefox-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-firefox
+      browsers: 'firefox'
+      test-files: ${{ needs.check-resumption.outputs.firefox-test-files }}
+      workers: '3'
+
+  test-safari-parallel:
+    needs: [gate, check-resumption, acquire-domain, deploy-auth, build-playwright-image, verify-chrome]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE == 'parallel-browsers' &&
+      needs.verify-chrome.result == 'success' &&
+      needs.check-resumption.outputs.safari-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-safari
+      browsers: 'safari'
+      test-files: ${{ needs.check-resumption.outputs.safari-test-files }}
+      workers: '3'
+
+  test-edge-parallel:
+    needs: [gate, check-resumption, acquire-domain, deploy-auth, build-playwright-image, verify-chrome]
+    if: >-
+      always() &&
+      vars.EXECUTION_MODE == 'parallel-browsers' &&
+      needs.verify-chrome.result == 'success' &&
+      needs.check-resumption.outputs.edge-resumption-mode != 'all-passed'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
+    secrets: inherit
+    with:
+      domain-number: '3'
+      app-type: skills
+      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
+      pr-number: ${{ github.event.pull_request.number }}
+      max-wait: 2400
+      total-shards: 1
+      run-type: main-edge
+      browsers: 'edge'
+      test-files: ${{ needs.check-resumption.outputs.edge-test-files }}
+      workers: '3'
+
+  # ============================================================
+  # SAVE TEST STATUS (for resumption on next run)
+  # ============================================================
+  save-status:
+    name: "Save Skills Status"
+    needs: [gate, test-chrome, test-firefox, test-safari, test-edge, test-chrome-parallel, test-firefox-parallel, test-safari-parallel, test-edge-parallel]
+    if: always()
+    runs-on: ubuntu-22.04
+    environment: iblai.app
+    steps:
+      - name: Save browser status to S3
+        env:
+          EXECUTION_MODE: ${{ vars.EXECUTION_MODE }}
+          CHROME_RESULT: ${{ vars.EXECUTION_MODE == 'parallel-browsers' && needs.test-chrome-parallel.result || needs.test-chrome.result }}
+          FIREFOX_RESULT: ${{ vars.EXECUTION_MODE == 'parallel-browsers' && needs.test-firefox-parallel.result || needs.test-firefox.result }}
+          SAFARI_RESULT: ${{ vars.EXECUTION_MODE == 'parallel-browsers' && needs.test-safari-parallel.result || needs.test-safari.result }}
+          EDGE_RESULT: ${{ vars.EXECUTION_MODE == 'parallel-browsers' && needs.test-edge-parallel.result || needs.test-edge.result }}
+          S3_BUCKET: ${{ secrets.S3_LOGS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_LOGS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_LOGS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          echo "=============================================="
+          echo "Saving Skills Test Status"
+          echo "=============================================="
+          echo "PR:     $PR_NUMBER"
+          echo "Commit: $COMMIT_SHA"
+          echo "Mode:   ${EXECUTION_MODE:-sequential}"
+          echo ""
+
+          PREV_STATUS="/tmp/prev-status.json"
+          S3_PATH="s3://$S3_BUCKET/pr/$PR_NUMBER/skills/run-status.json"
+          aws s3 cp "$S3_PATH" "$PREV_STATUS" --region "$AWS_REGION" 2>/dev/null || echo '{}' > "$PREV_STATUS"
+
+          echo "Previous status:"
+          cat "$PREV_STATUS"
+          echo ""
+
+          echo "Job results:"
+          echo "  Chrome:  $CHROME_RESULT"
+          echo "  Firefox: $FIREFOX_RESULT"
+          echo "  Safari:  $SAFARI_RESULT"
+          echo "  Edge:    $EDGE_RESULT"
+          echo ""
+
+          get_status() {
+            local result=$1 browser=$2
+
+            if [ "$result" = "skipped" ]; then
+              jq -r ".browsers.${browser} // \"pending\"" "$PREV_STATUS" 2>/dev/null || echo "pending"
+              return
+            fi
+
+            if [ "$result" != "success" ]; then
+              echo "failed"
+              return
+            fi
+
+            local results_file="/tmp/test-results-${browser}.json"
+            local results_path="s3://$S3_BUCKET/pr/$PR_NUMBER/skills/test-results-${browser}.json"
+
+            if aws s3 cp "$results_path" "$results_file" --region "$AWS_REGION" >/dev/null 2>&1; then
+              local failed_count
+              failed_count=$(jq '[.tests | to_entries[] | select(.value == "failed")] | length' "$results_file" 2>/dev/null || echo "-1")
+
+              if [ "$failed_count" = "0" ]; then
+                echo "passed"
+              elif [ "$failed_count" = "-1" ]; then
+                echo "passed"
+              else
+                echo "failed"
+              fi
+            else
+              echo "passed"
+            fi
+          }
+
+          CHROME_STATUS=$(get_status "$CHROME_RESULT" "chrome")
+          FIREFOX_STATUS=$(get_status "$FIREFOX_RESULT" "firefox")
+          SAFARI_STATUS=$(get_status "$SAFARI_RESULT" "safari")
+          EDGE_STATUS=$(get_status "$EDGE_RESULT" "edge")
+
+          echo "Computed status:"
+          echo "  Chrome:  $CHROME_STATUS"
+          echo "  Firefox: $FIREFOX_STATUS"
+          echo "  Safari:  $SAFARI_STATUS"
+          echo "  Edge:    $EDGE_STATUS"
+          echo ""
+
+          cat > /tmp/run-status.json <<EOF
+          {
+            "commit": "$COMMIT_SHA",
+            "browsers": {
+              "chrome": "$CHROME_STATUS",
+              "firefox": "$FIREFOX_STATUS",
+              "safari": "$SAFARI_STATUS",
+              "edge": "$EDGE_STATUS"
+            }
+          }
+          EOF
+
+          echo "Uploading to: $S3_PATH"
+          aws s3 cp /tmp/run-status.json "$S3_PATH" \
+            --region "$AWS_REGION" \
+            --content-type "application/json"
+          echo "Skills status saved"
+
+  # ============================================================
+  # RELEASE DOMAIN LOCK
+  # ============================================================
+  release-domain:
+    needs: [gate, acquire-domain, lint, typecheck, coverage, claude-review-quality, claude-review-uiux, check-prod-versions, build-app-image, build-playwright-image, deploy-app, deploy-auth, verify-chrome, test-chrome, verify-firefox, test-firefox, verify-safari, test-safari, verify-edge, test-edge, test-chrome-parallel, test-firefox-parallel, test-safari-parallel, test-edge-parallel, save-status]
+    if: >-
+      always() &&
+      needs.acquire-domain.result == 'success'
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-domain-lock.yml@main
+    with:
+      action: release
+      app-type: testing
+      domain-number: '3'
+
+  # ============================================================
+  # FINAL SUMMARY
+  # ============================================================
+  summary:
+    needs: [gate, acquire-domain, lint, typecheck, coverage, claude-review-quality, claude-review-uiux, check-prod-versions, build-app-image, build-playwright-image, deploy-app, deploy-auth, verify-chrome, test-chrome, verify-firefox, test-firefox, verify-safari, test-safari, verify-edge, test-edge, test-chrome-parallel, test-firefox-parallel, test-safari-parallel, test-edge-parallel, save-status, release-domain]
+    if: always()
+    runs-on: ubuntu-22.04
+    env:
+      CLOUDFRONT_DOMAIN: ${{ vars.CLOUDFRONT_DOMAIN || 'tests.iblai.app' }}
+    steps:
+      - name: Generate summary
+        run: |
+          echo "# Skills PR Test Validation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**PR:** #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "## Code Quality Verification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|:------:|" >> $GITHUB_STEP_SUMMARY
+
+          LINT_RESULT="${{ needs.lint.outputs.result }}"
+          if [[ "$LINT_RESULT" == "success" ]]; then
+            echo "| Linting | :white_check_mark: PASSED |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Linting | :x: FAILED |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          TYPECHECK_RESULT="${{ needs.typecheck.outputs.result }}"
+          if [[ "$TYPECHECK_RESULT" == "success" ]]; then
+            echo "| TypeCheck | :white_check_mark: PASSED |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| TypeCheck | :x: FAILED |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          COVERAGE_RESULT="${{ needs.coverage.outputs.result }}"
+          if [[ "$COVERAGE_RESULT" == "success" ]]; then
+            echo "| Unit Coverage | :white_check_mark: PASSED |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Unit Coverage | :x: FAILED |" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "## Claude Reviews" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Review | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|:------:|" >> $GITHUB_STEP_SUMMARY
+
+          QUALITY_RESULT="${{ needs.claude-review-quality.outputs.result }}"
+          if [[ "$QUALITY_RESULT" == "success" ]]; then
+            echo "| Code Quality | :white_check_mark: Completed |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Code Quality | :x: Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          UIUX_RESULT="${{ needs.claude-review-uiux.outputs.result }}"
+          if [[ "$UIUX_RESULT" == "success" ]]; then
+            echo "| UI/UX | :white_check_mark: Completed |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| UI/UX | :x: Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "## Skills Browser Tests" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ vars.EXECUTION_MODE }}" == "parallel-browsers" ]]; then
+            MODE_LABEL="Parallel"
+            S_CHROME="${{ needs.test-chrome-parallel.outputs.result }}"
+            S_FIREFOX="${{ needs.test-firefox-parallel.outputs.result }}"
+            S_SAFARI="${{ needs.test-safari-parallel.outputs.result }}"
+            S_EDGE="${{ needs.test-edge-parallel.outputs.result }}"
+          else
+            MODE_LABEL="Sequential"
+            S_CHROME="${{ needs.test-chrome.outputs.result }}"
+            S_FIREFOX="${{ needs.test-firefox.outputs.result }}"
+            S_SAFARI="${{ needs.test-safari.outputs.result }}"
+            S_EDGE="${{ needs.test-edge.outputs.result }}"
+          fi
+
+          echo "### ${MODE_LABEL} Mode" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Browser | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|:------:|" >> $GITHUB_STEP_SUMMARY
+
+          for PAIR in "Chrome:$S_CHROME" "Firefox:$S_FIREFOX" "Safari:$S_SAFARI" "Edge:$S_EDGE"; do
+            BROWSER="${PAIR%%:*}"
+            RESULT="${PAIR#*:}"
+            if [[ "$RESULT" == "success" ]]; then
+              echo "| $BROWSER | :white_check_mark: PASSED |" >> $GITHUB_STEP_SUMMARY
+            elif [[ -z "$RESULT" ]]; then
+              echo "| $BROWSER | :fast_forward: SKIPPED (resumption) |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| $BROWSER | :x: FAILED |" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Check test results
+        if: always()
+        run: |
+          FAILED=false
+
+          echo "============================================"
+          echo "Checking test results..."
+          echo "============================================"
+
+          if [[ "${{ needs.lint.outputs.result }}" != "success" ]]; then
+            echo "Linting FAILED"; FAILED=true
+          else
+            echo "Linting PASSED"
+          fi
+
+          if [[ "${{ needs.typecheck.outputs.result }}" != "success" ]]; then
+            echo "TypeCheck FAILED"; FAILED=true
+          else
+            echo "TypeCheck PASSED"
+          fi
+
+          if [[ "${{ needs.coverage.outputs.result }}" != "success" ]]; then
+            echo "Unit coverage FAILED"; FAILED=true
+          else
+            echo "Unit coverage PASSED"
+          fi
+
+          echo ""
+          echo "Checking browser tests..."
+          if [[ "${{ vars.EXECUTION_MODE }}" == "parallel-browsers" ]]; then
+            S_CHROME="${{ needs.test-chrome-parallel.outputs.result }}"
+            S_FIREFOX="${{ needs.test-firefox-parallel.outputs.result }}"
+            S_SAFARI="${{ needs.test-safari-parallel.outputs.result }}"
+            S_EDGE="${{ needs.test-edge-parallel.outputs.result }}"
+          else
+            S_CHROME="${{ needs.test-chrome.outputs.result }}"
+            S_FIREFOX="${{ needs.test-firefox.outputs.result }}"
+            S_SAFARI="${{ needs.test-safari.outputs.result }}"
+            S_EDGE="${{ needs.test-edge.outputs.result }}"
+          fi
+
+          for PAIR in "Chrome:$S_CHROME" "Firefox:$S_FIREFOX" "Safari:$S_SAFARI" "Edge:$S_EDGE"; do
+            BROWSER="${PAIR%%:*}"
+            RESULT="${PAIR#*:}"
+            if [[ "$RESULT" == "success" || -z "$RESULT" ]]; then
+              echo "Skills $BROWSER tests passed${RESULT:+}${RESULT:-" (skipped - resumption)"}"
+            else
+              echo "Skills $BROWSER tests failed"; FAILED=true
+            fi
+          done
+
+          echo ""
+          echo "============================================"
+          if [[ "$FAILED" == "true" ]]; then
+            echo "WORKFLOW FAILED - One or more checks failed"
+            exit 1
+          else
+            echo "WORKFLOW PASSED - All checks passed!"
+            exit 0
+          fi


### PR DESCRIPTION
## Summary

- Adds thin orchestrator workflow (`spa-pr-validation.yml`) that calls reusable workflows from `ibl-web-ops` for the full PR validation pipeline
- Triggered by adding the `run-tests` label to PRs targeting `main`
- All heavy logic lives in `ibl-web-ops` reusable workflows — this file is ~782 lines of job orchestration with zero business logic

## What it does

1. **Gate** — detects app vs test-only changes, decides whether to build a new Docker image or use prod
2. **Verification** (parallel) — lint, typecheck, unit coverage, Claude AI reviews
3. **Docker builds** — app image to ECR (`ibl-skills-spa-pro`), playwright image to OCIR (`ibl-skills-playwright`)
4. **Deployment** — deploys skills + auth to domain 3 staging
5. **E2E tests** — sequential or parallel browser tests (chrome/firefox/safari/edge) via OCI Container Instances
6. **Test resumption** — skips previously passed browsers when only test files changed
7. **Domain locking** — acquires/releases domain 3 for exclusive test access
8. **Summary** — generates GitHub step summary with results table

## Differences from mentorai

- `app-type: skills` / `app-name: SKILLS`
- ECR image: `ibl-skills-spa-pro`, OCIR: `ibl-skills-playwright`
- Deployment path: `/ibl/app/ibl-spa/skills3`
- Health port: `5023` (vs mentor's `5007`)
- Test max-wait: `2400` (vs mentor's `5400`)

## Prerequisites

- ibl-web-ops Phase 2 reusable workflows pushed to main (done)
- Org-level secrets configured (AWS, OCI, S3, Anthropic, SSH)
- Repo variables: `NODES`, `NODES_SPA_CHECK`, `IBL_CLI_VENV_NAME`, `EXECUTION_MODE`
- Playwright tests in `/tests` directory with `tests/Dockerfile`

## Test plan

- [ ] Create a test PR, add `run-tests` label
- [ ] Verify lint, typecheck, coverage run successfully
- [ ] Verify domain lock acquired/released
- [ ] Verify deployment to staging
- [ ] Verify OCI test containers launch and complete
- [ ] Verify summary appears on PR

Generated with [Claude Code](https://claude.com/claude-code)