### PR TITLE
Update PR validation to use e2e/ test directory

### DIFF
--- a/.github/workflows/spa-pr-validation.yml
+++ b/.github/workflows/spa-pr-validation.yml
@@ -50,7 +50,7 @@ jobs:
               - 'tailwind.config.*'
               - 'Dockerfile'
             tests:
-              - 'tests/**'
+              - 'e2e/**'
 
       - name: Decide build strategy
         id: decide
@@ -86,7 +86,7 @@ jobs:
     with:
       app-name: skills
       pr-number: ${{ github.event.pull_request.number }}
-      test-dir: tests
+      test-dir: e2e/tests
     secrets:
       s3-bucket: ${{ secrets.S3_LOGS_BUCKET }}
       aws-access-key-id: ${{ secrets.S3_LOGS_ACCESS_KEY_ID }}
@@ -209,8 +209,8 @@ jobs:
     uses: iblai/ibl-web-ops/.github/workflows/reusable-pr-docker-build.yml@main
     secrets: inherit
     with:
-      dockerfile-path: tests/Dockerfile
-      build-context: tests/
+      dockerfile-path: e2e/Dockerfile
+      build-context: .
       image-name: ibl-skills-playwright
       registry-type: ocir
       event-name: pull_request


### PR DESCRIPTION
## Summary
- Updates `spa-pr-validation.yml` to use `e2e/` paths instead of `tests/`
- Changes: `dockerfile-path: e2e/Dockerfile`, `build-context: .`, `test-dir: e2e/tests`, change detection filter `e2e/**`
- Skillsai still needs `e2e/Dockerfile`, `e2e/docker-entrypoint.sh`, and test specs added separately

## Test plan
- [ ] Verify workflow passes static validation
- [ ] Add Playwright setup when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)