### PR TITLE
feat(ci): add PR gate for branch protection with commit status API

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,44 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  statuses: write
+
+jobs:
+  pr-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set validation status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const sha = context.payload.pull_request.head.sha;
+
+            if (!labels.includes('run-tests')) {
+              // No validation required — allow merge
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: 'PR Validation',
+                description: 'Tests not required (add run-tests label to trigger)',
+              });
+              core.info('No run-tests label — gate passes');
+            } else {
+              // Label present — block merge until validation workflow completes
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'pending',
+                context: 'PR Validation',
+                description: 'Waiting for SPA PR Validation to complete...',
+              });
+              core.info('run-tests label found — set pending, validation workflow will update');
+            }

--- a/.github/workflows/spa-pr-validation.yml
+++ b/.github/workflows/spa-pr-validation.yml
@@ -7,6 +7,11 @@ on:
 
 run-name: "PR #${{ github.event.pull_request.number }} - Skills Test Validation"
 
+permissions:
+  statuses: write
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: pr-validation-skills-${{ github.event.pull_request.number }}
   cancel-in-progress: false
@@ -729,6 +734,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
       - name: Check test results
+        id: check-results
         if: always()
         run: |
           FAILED=false
@@ -788,3 +794,18 @@ jobs:
             echo "WORKFLOW PASSED - All checks passed!"
             exit 0
           fi
+
+      - name: Update PR gate status
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const passed = '${{ steps.check-results.outcome }}' === 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: passed ? 'success' : 'failure',
+              context: 'PR Validation',
+              description: passed ? 'All checks passed' : 'Some checks failed',
+            });


### PR DESCRIPTION
- pr-gate.yml: lightweight workflow (~3s) that runs on all PR events and sets a "PR Validation" commit status
  - No run-tests label: status = success (PR is mergeable)
  - run-tests label present: status = pending (blocks merge until validation completes)
- spa-pr-validation.yml: summary job now updates the same "PR Validation" commit status to success/failure when validation finishes

Branch protection should require the "PR Validation" status check.


## Checklist
- [ ] Tests were added/updated according to the feature/bugfix/change made
- [ ] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
