### PR TITLE
fix: course pagination should only open on course tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.9.10]
+
+- fix: course pagination should only open on course tab
+
 ## [0.9.9]
 
 - feat: course content page UI display optimized

--- a/components/edx-iframe/edx-iframe.tsx
+++ b/components/edx-iframe/edx-iframe.tsx
@@ -216,7 +216,7 @@ export const EdxIframe = () => {
               allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
             />
           )}
-          {iframeLoaded &&
+          {iframeLoaded && activeTab === 'course' &&
             !fetchingIframeData &&
             (!navigator.isPreviousHidden() || !navigator.isNextHidden()) && (
               <div

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibl-web-nextjs-skills-spa",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": false,
   "packageManager": "pnpm@10.11.1",
   "engines": {


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
