### PR TITLE
fix: agent and course content mode logic swapped

### DIFF
--- a/app/course-content/[course_id]/__tests__/layout.test.tsx
+++ b/app/course-content/[course_id]/__tests__/layout.test.tsx
@@ -213,7 +213,7 @@ describe('CourseContentLayout', () => {
     expect(screen.getByText('Discussion')).toBeInTheDocument();
   });
 
-  it('hides Agent tab when course.agent_content_mode is false', () => {
+  it('hides Agent tab when course.agent_content_mode is not true', () => {
     vi.mocked(useCourseDetail).mockReturnValue({
       handleFetchCourseInfo: mockHandleFetchCourseInfo,
       handleFetchCourseSyllabus: mockHandleFetchCourseSyllabus,
@@ -237,14 +237,14 @@ describe('CourseContentLayout', () => {
     expect(screen.getByText('Course')).toBeInTheDocument();
   });
 
-  it('hides Course tab when course.course_content_mode is not true', () => {
+  it('hides Course tab when course.course_content_mode is false', () => {
     vi.mocked(useCourseDetail).mockReturnValue({
       handleFetchCourseInfo: mockHandleFetchCourseInfo,
       handleFetchCourseSyllabus: mockHandleFetchCourseSyllabus,
       handleOpenLesson: mockHandleOpenLesson,
       handleFetchCourseProgress: mockHandleFetchCourseProgress,
       handleFetchCourseCompletion: mockHandleFetchCourseCompletion,
-      course: { agent_content_mode: true, course_content_mode: null },
+      course: { agent_content_mode: true, course_content_mode: false },
       courseInfoLoadingState: 'successful',
       courseOutline: null,
       courseOutlineLoading: false,
@@ -261,7 +261,7 @@ describe('CourseContentLayout', () => {
     expect(screen.queryByText('Course')).not.toBeInTheDocument();
   });
 
-  it('shows Agent tab when course.agent_content_mode is null', () => {
+  it('hides Agent tab when course.agent_content_mode is null', () => {
     vi.mocked(useCourseDetail).mockReturnValue({
       handleFetchCourseInfo: mockHandleFetchCourseInfo,
       handleFetchCourseSyllabus: mockHandleFetchCourseSyllabus,
@@ -281,7 +281,55 @@ describe('CourseContentLayout', () => {
         <div>children</div>
       </CourseContentLayout>,
     );
-    expect(screen.getByText('Agent')).toBeInTheDocument();
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument();
+    expect(screen.getByText('Course')).toBeInTheDocument();
+  });
+
+  it('shows Course tab when course.course_content_mode is null', () => {
+    vi.mocked(useCourseDetail).mockReturnValue({
+      handleFetchCourseInfo: mockHandleFetchCourseInfo,
+      handleFetchCourseSyllabus: mockHandleFetchCourseSyllabus,
+      handleOpenLesson: mockHandleOpenLesson,
+      handleFetchCourseProgress: mockHandleFetchCourseProgress,
+      handleFetchCourseCompletion: mockHandleFetchCourseCompletion,
+      course: { agent_content_mode: true, course_content_mode: null },
+      courseInfoLoadingState: 'successful',
+      courseOutline: null,
+      courseOutlineLoading: false,
+      courseCompletion: null,
+      courseGradingPolicyActive: false,
+    } as any);
+
+    render(
+      <CourseContentLayout params={defaultParams}>
+        <div>children</div>
+      </CourseContentLayout>,
+    );
+    expect(screen.getByText('Course')).toBeInTheDocument();
+  });
+
+  it('shows Course tab when both course_content_mode and agent_content_mode are false', () => {
+    vi.mocked(useCourseDetail).mockReturnValue({
+      handleFetchCourseInfo: mockHandleFetchCourseInfo,
+      handleFetchCourseSyllabus: mockHandleFetchCourseSyllabus,
+      handleOpenLesson: mockHandleOpenLesson,
+      handleFetchCourseProgress: mockHandleFetchCourseProgress,
+      handleFetchCourseCompletion: mockHandleFetchCourseCompletion,
+      course: { agent_content_mode: false, course_content_mode: false },
+      courseInfoLoadingState: 'successful',
+      courseOutline: null,
+      courseOutlineLoading: false,
+      courseCompletion: null,
+      courseGradingPolicyActive: false,
+    } as any);
+
+    render(
+      <CourseContentLayout params={defaultParams}>
+        <div>children</div>
+      </CourseContentLayout>,
+    );
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument();
+    expect(screen.getByText('Course')).toBeInTheDocument();
   });
 
   it('hides Instructor tab when user is not platform admin', () => {

--- a/app/course-content/[course_id]/layout.tsx
+++ b/app/course-content/[course_id]/layout.tsx
@@ -131,8 +131,9 @@ export default function CourseContentLayout({
     handleOpenLesson(lessonId, false, currentTab === 'agent' ? 'agent' : 'course');
   };
 
-  const agentTabVisible = !course || course.agent_content_mode !== false;
-  const courseTabVisible = !course || course.course_content_mode === true;
+  const agentTabVisible = !course || course.agent_content_mode === true;
+  const courseTabVisible =
+    !course || course.course_content_mode !== false || course.agent_content_mode === false;
 
   return (
     <CourseAccessGuard

--- a/components/__tests__/course-access-guard.test.tsx
+++ b/components/__tests__/course-access-guard.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
+const mockPathname = { current: '/course-content/course-v1:test+course+2024/course' };
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  usePathname: () => mockPathname.current,
 }));
 
 vi.mock('@/utils/helpers', () => ({
@@ -161,7 +164,8 @@ describe('CourseAccessGuard', () => {
   });
 
   describe('tab access', () => {
-    it('redirects to /error/403 on agent tab when agent_content_mode is false', () => {
+    it('silently redirects agent tab to course tab when agent_content_mode is false but course is accessible', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/agent';
       render(
         <CourseAccessGuard
           course={{ platform_key: 'test-tenant', agent_content_mode: false } as any}
@@ -171,11 +175,13 @@ describe('CourseAccessGuard', () => {
           <div>content</div>
         </CourseAccessGuard>,
       );
-      expect(mockPush).toHaveBeenCalledWith('/error/403');
+      expect(mockReplace).toHaveBeenCalledWith('/course-content/course-v1:test+course+2024/course');
+      expect(mockPush).not.toHaveBeenCalled();
       expect(screen.queryByText('content')).not.toBeInTheDocument();
     });
 
     it('does not redirect on agent tab when agent_content_mode is true', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/agent';
       render(
         <CourseAccessGuard
           course={{ platform_key: 'test-tenant', agent_content_mode: true } as any}
@@ -186,10 +192,12 @@ describe('CourseAccessGuard', () => {
         </CourseAccessGuard>,
       );
       expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
       expect(screen.getByText('content')).toBeInTheDocument();
     });
 
-    it('does not redirect on agent tab when agent_content_mode is null', () => {
+    it('silently redirects agent tab to course tab when agent_content_mode is null', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/agent';
       render(
         <CourseAccessGuard
           course={{ platform_key: 'test-tenant', agent_content_mode: null } as any}
@@ -199,11 +207,55 @@ describe('CourseAccessGuard', () => {
           <div>content</div>
         </CourseAccessGuard>,
       );
+      expect(mockReplace).toHaveBeenCalledWith('/course-content/course-v1:test+course+2024/course');
       expect(mockPush).not.toHaveBeenCalled();
-      expect(screen.getByText('content')).toBeInTheDocument();
     });
 
-    it('redirects to /error/403 on course tab when course_content_mode is not true', () => {
+    it('redirects to /error/403 on agent tab when both tabs are inaccessible', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/agent';
+      render(
+        <CourseAccessGuard
+          course={
+            {
+              platform_key: 'test-tenant',
+              agent_content_mode: null,
+              course_content_mode: false,
+            } as any
+          }
+          courseInfoLoadingState="successful"
+          currentTab="agent"
+        >
+          <div>content</div>
+        </CourseAccessGuard>,
+      );
+      expect(mockPush).toHaveBeenCalledWith('/error/403');
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('silently redirects course tab to agent tab when course_content_mode is false but agent is accessible', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/course';
+      render(
+        <CourseAccessGuard
+          course={
+            {
+              platform_key: 'test-tenant',
+              course_content_mode: false,
+              agent_content_mode: true,
+            } as any
+          }
+          courseInfoLoadingState="successful"
+          currentTab="course"
+        >
+          <div>content</div>
+        </CourseAccessGuard>,
+      );
+      expect(mockReplace).toHaveBeenCalledWith('/course-content/course-v1:test+course+2024/agent');
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+
+    it('redirects to /error/403 on course tab when both tabs are inaccessible', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/course';
       render(
         <CourseAccessGuard
           course={{ platform_key: 'test-tenant', course_content_mode: false } as any}
@@ -214,9 +266,11 @@ describe('CourseAccessGuard', () => {
         </CourseAccessGuard>,
       );
       expect(mockPush).toHaveBeenCalledWith('/error/403');
+      expect(mockReplace).not.toHaveBeenCalled();
     });
 
-    it('redirects to /error/403 on course tab when course_content_mode is null', () => {
+    it('does not redirect on course tab when course_content_mode is null', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/course';
       render(
         <CourseAccessGuard
           course={{ platform_key: 'test-tenant', course_content_mode: null } as any}
@@ -226,10 +280,13 @@ describe('CourseAccessGuard', () => {
           <div>content</div>
         </CourseAccessGuard>,
       );
-      expect(mockPush).toHaveBeenCalledWith('/error/403');
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
+      expect(screen.getByText('content')).toBeInTheDocument();
     });
 
     it('does not redirect on course tab when course_content_mode is true', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/course';
       render(
         <CourseAccessGuard
           course={{ platform_key: 'test-tenant', course_content_mode: true } as any}
@@ -240,10 +297,34 @@ describe('CourseAccessGuard', () => {
         </CourseAccessGuard>,
       );
       expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+
+    it('does not redirect on course tab when both course_content_mode and agent_content_mode are false', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/course';
+      render(
+        <CourseAccessGuard
+          course={
+            {
+              platform_key: 'test-tenant',
+              course_content_mode: false,
+              agent_content_mode: false,
+            } as any
+          }
+          courseInfoLoadingState="successful"
+          currentTab="course"
+        >
+          <div>content</div>
+        </CourseAccessGuard>,
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
       expect(screen.getByText('content')).toBeInTheDocument();
     });
 
     it('does not redirect on other tabs regardless of content mode flags', () => {
+      mockPathname.current = '/course-content/course-v1:test+course+2024/progress';
       render(
         <CourseAccessGuard
           course={
@@ -260,6 +341,7 @@ describe('CourseAccessGuard', () => {
         </CourseAccessGuard>,
       );
       expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
       expect(screen.getByText('content')).toBeInTheDocument();
     });
   });

--- a/components/course-access-guard.tsx
+++ b/components/course-access-guard.tsx
@@ -2,7 +2,7 @@
 
 import type React from 'react';
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { getTenant } from '@/utils/helpers';
 import type { CourseEdxData } from '@/types/courses';
 import type { CourseInfoLoadingState } from '@/hooks/courses/use-course-detail';
@@ -19,6 +19,7 @@ export function CourseAccessGuard({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
 
   const isLoaded = courseInfoLoadingState === 'successful' || courseInfoLoadingState === 'failure';
 
@@ -30,21 +31,44 @@ export function CourseAccessGuard({
 
   const isNotFound = courseInfoLoadingState === 'failure' && !course;
 
+  const agentAccessible = isLoaded && !!course && course.agent_content_mode === true;
+  const courseAccessible =
+    isLoaded &&
+    !!course &&
+    (course.course_content_mode !== false || course.agent_content_mode === false);
+
+  const onAgentTab = currentTab === 'agent';
+  const onCourseTab = currentTab === 'course';
+
+  const shouldRedirectAgentToCourse = onAgentTab && !agentAccessible && courseAccessible;
+  const shouldRedirectCourseToAgent = onCourseTab && !courseAccessible && agentAccessible;
+  const shouldRedirectToSibling = shouldRedirectAgentToCourse || shouldRedirectCourseToAgent;
+
   const isTabDisabled =
     isLoaded &&
     !!course &&
-    ((currentTab === 'agent' && course.agent_content_mode === false) ||
-      (currentTab === 'course' && course.course_content_mode !== true));
+    !shouldRedirectToSibling &&
+    ((onAgentTab && !agentAccessible) || (onCourseTab && !courseAccessible));
 
   useEffect(() => {
-    if (isUnauthorizedTenant || isTabDisabled) {
+    if (shouldRedirectToSibling && pathname) {
+      const siblingTab = shouldRedirectAgentToCourse ? 'course' : 'agent';
+      const siblingPath = pathname.replace(/\/(agent|course)$/, `/${siblingTab}`);
+      router.replace(siblingPath);
+    } else if (isUnauthorizedTenant || isTabDisabled) {
       router.push('/error/403');
     } else if (isNotFound) {
       router.push('/error/404');
     }
-  }, [isUnauthorizedTenant, isNotFound, isTabDisabled]);
+  }, [
+    isUnauthorizedTenant,
+    isNotFound,
+    isTabDisabled,
+    shouldRedirectToSibling,
+    shouldRedirectAgentToCourse,
+  ]);
 
-  if (!isLoaded || isUnauthorizedTenant || isNotFound || isTabDisabled) {
+  if (!isLoaded || isUnauthorizedTenant || isNotFound || isTabDisabled || shouldRedirectToSibling) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-amber-500 border-t-transparent" />

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -87,9 +87,9 @@ When adding a new page or modifying an existing user flow:
 - [x] Bookmarks tab is accessible from the course content navigation _(if available)_
 - [x] URL updates correctly when switching between tabs
 - [x] No error messages (Bad request, 500, Server error) appear on any course tab
-- [x] Agent tab is visible when `course.agent_content_mode !== false` and its link points at `/course-content/<id>/agent`
+- [x] Agent tab is visible when `course.agent_content_mode === true` and its link points at `/course-content/<id>/agent`
 - [x] `/agent` route mounts the `<mentor-ai>` chat full-width and keeps the edX iframe attached with `display:none`
-- [x] `CourseAccessGuard` redirects to `/error/403` when visiting `/agent` on a course where `agent_content_mode === false`
+- [x] `CourseAccessGuard` redirects to `/error/403` when visiting `/agent` on a course where `agent_content_mode !== true`
 - [x] Previous / Keep Learning buttons in the tabs row switch units and flip the URL's `unit_id`
 - [x] Switching units on the `/agent` tab fires the `Switched to "<unit>"` confirmation toast
 

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -251,7 +251,7 @@
         },
         {
           "id": "tabs-13",
-          "description": "Agent tab link visible when agent_content_mode !== false, pointing at /course-content/<id>/agent",
+          "description": "Agent tab link visible when agent_content_mode === true, pointing at /course-content/<id>/agent",
           "status": "covered"
         },
         {
@@ -261,7 +261,7 @@
         },
         {
           "id": "tabs-15",
-          "description": "CourseAccessGuard redirects to /error/403 when visiting /agent with agent_content_mode=false",
+          "description": "CourseAccessGuard redirects to /error/403 when visiting /agent with agent_content_mode !== true",
           "status": "covered"
         },
         {

--- a/e2e/journeys/05-course-content-tabs.spec.ts
+++ b/e2e/journeys/05-course-content-tabs.spec.ts
@@ -489,7 +489,7 @@ test.describe('Journey 05: Course Content Tabs', () => {
     const hasAgentTab = await agentTab.isVisible({ timeout: 30_000 }).catch(() => false);
 
     if (!hasAgentTab) {
-      logger.info('Agent tab not visible — course has agent_content_mode=false; skipping');
+      logger.info('Agent tab not visible — course has agent_content_mode !== true; skipping');
       test.skip();
       return;
     }
@@ -540,7 +540,7 @@ test.describe('Journey 05: Course Content Tabs', () => {
     logger.info('Agent tab renders mentor-ai and keeps edX iframe display:none');
   });
 
-  test('Checkpoint 15: Agent tab route rejects courses with agent_content_mode=false', async ({
+  test('Checkpoint 15: Agent tab route rejects courses with agent_content_mode !== true', async ({
     page,
   }) => {
     const ready = await navigateToCourseContent(page);
@@ -555,7 +555,7 @@ test.describe('Journey 05: Course Content Tabs', () => {
 
     if (hasAgentTab) {
       logger.info(
-        'Agent tab is visible — cannot assert the redirect path for agent_content_mode=false; skipping',
+        'Agent tab is visible — cannot assert the redirect path for agent_content_mode !== true; skipping',
       );
       test.skip();
       return;
@@ -568,7 +568,7 @@ test.describe('Journey 05: Course Content Tabs', () => {
     await page.goto(agentUrl, { timeout: 60_000 });
     await page.waitForURL(/\/error\/403/, { timeout: 30_000 });
     await expect(page).toHaveURL(/\/error\/403/);
-    logger.info('Agent route redirects to /error/403 when agent_content_mode=false');
+    logger.info('Agent route redirects to /error/403 when agent_content_mode !== true');
   });
 
   test('Checkpoint 16: Previous/Keep Learning buttons navigate units from the tabs row', async ({

--- a/hooks/courses/__tests__/use-course-detail.test.ts
+++ b/hooks/courses/__tests__/use-course-detail.test.ts
@@ -138,31 +138,48 @@ describe('useCourseDetail', () => {
   });
 
   describe('handleAccessCourse', () => {
-    it('routes to /agent by default when course data is unavailable', () => {
+    it('routes to /course by default when course data is unavailable', () => {
       (inIframe as ReturnType<typeof vi.fn>).mockReturnValue(false);
       const { result } = renderHook(() => useCourseDetail('course-123'));
       act(() => {
         result.current.handleAccessCourse();
       });
-      expect(mockPush).toHaveBeenCalledWith('/course-content/course-123/agent');
+      expect(mockPush).toHaveBeenCalledWith('/course-content/course-123/course');
     });
 
-    it('opens /agent in new tab when in iframe and agent is default', () => {
+    it('opens /course in new tab when in iframe and course is default', () => {
       (inIframe as ReturnType<typeof vi.fn>).mockReturnValue(true);
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
       const { result } = renderHook(() => useCourseDetail('course-123'));
       act(() => {
         result.current.handleAccessCourse();
       });
-      expect(openSpy).toHaveBeenCalledWith('/course-content/course-123/agent', '_blank');
+      expect(openSpy).toHaveBeenCalledWith('/course-content/course-123/course', '_blank');
       openSpy.mockRestore();
     });
 
-    it('routes to /course when agent_content_mode is false', async () => {
+    it('routes to /agent when agent_content_mode is true', async () => {
       (inIframe as ReturnType<typeof vi.fn>).mockReturnValue(false);
       mockHandleFetchCourseMetaData.mockResolvedValue({
         display_name: 'Test',
-        agent_content_mode: false,
+        agent_content_mode: true,
+        course_content_mode: true,
+      });
+      const { result } = renderHook(() => useCourseDetail('course-123'));
+      await act(async () => {
+        await result.current.handleFetchCourseInfo();
+      });
+      act(() => {
+        result.current.handleAccessCourse();
+      });
+      expect(mockPush).toHaveBeenCalledWith('/course-content/course-123/agent');
+    });
+
+    it('routes to /course when agent_content_mode is null', async () => {
+      (inIframe as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      mockHandleFetchCourseMetaData.mockResolvedValue({
+        display_name: 'Test',
+        agent_content_mode: null,
         course_content_mode: true,
       });
       const { result } = renderHook(() => useCourseDetail('course-123'));

--- a/hooks/courses/use-course-detail.ts
+++ b/hooks/courses/use-course-detail.ts
@@ -76,7 +76,7 @@ export const useCourseDetail = (courseId: string) => {
   };
 
   const handleAccessCourse = () => {
-    const defaultTab = course?.agent_content_mode !== false ? 'agent' : 'course';
+    const defaultTab = course?.agent_content_mode === true ? 'agent' : 'course';
     const url = `/course-content/${courseId}/${defaultTab}`;
     if (inIframe()) {
       window.open(url, '_blank');


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- agent and course content mode logic swapped