### PR TITLE
fix: assessment xblock mentor display css reverted

### DIFF
--- a/public/styles/lms.css
+++ b/public/styles/lms.css
@@ -559,6 +559,7 @@ body .fa {
 /* =============================================
    ASSESSMENT FEATURE - CSS UPDATES
    ============================================= */
-main:has([data-block-type='ibl_mentor_xblock']) > .xblock > :not(.vert-mod) {
+/* main:has([data-block-type='ibl_mentor_xblock']) > .xblock > :not(.vert-mod) {
   display: none !important;
 }
+ */


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- fix: assessment xblock mentor display css reverted