### PR TITLE
ci(docker): flip run-name 'Build skills' → 'Build lms'

### DIFF
--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
       - 'skills-v*'
 
-run-name: 'Build skills ${{ github.ref_name }}'
+run-name: 'Build lms ${{ github.ref_name }}'
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary

The repo was renamed `iblai/skillsai` → `iblai/lms` on 2026-03-04 but `.github/workflows/trigger-docker-build.yml`'s `run-name` still reads `'Build skills'`. **One-line cosmetic flip.**

```diff
-run-name: 'Build skills ${{ github.ref_name }}'
+run-name: 'Build lms ${{ github.ref_name }}'
```

## What's NOT changed (and why)

`app_name: skills` (line 31, passed into `iblai/iblai-web-ops/.github/workflows/reusable-spa-docker-build.yml@main`) is left alone deliberately. That parameter controls the ECR push target — `iblai-${app_name}-spa-pro` — so flipping it to `lms` would silently start failing every release because `iblai-lms-spa-pro` does not exist:

```
$ aws ecr describe-repositories --region us-east-1 --repository-names iblai-lms-spa-pro
RepositoryNotFoundException: The repository with name 'iblai-lms-spa-pro' does not exist
```

The current arrangement matches how `SKILLSAI` worked in the cli-ops/prod-images catalog before today's renames: SKILLSAI shared the SKILLS image via `iblai-skills-spa-pro`. After the rename in [`iblai/iblai-cli-ops#1985`](https://github.com/iblai/iblai-cli-ops/pull/1985) and [`iblai/iblai-prod-images#154`](https://github.com/iblai/iblai-prod-images/pull/154), the catalog still points `spa.lms` at `iblai-skills-spa-pro` — same image, new key. So this workflow's `app_name: skills` continues to be correct.

## Follow-up — dedicated `iblai-lms-spa-pro` image (out of scope here)

If you want LMS to publish a distinct image instead of sharing SKILLS', the additional work is:

1. `aws ecr create-repository --repository-name iblai-lms-spa-pro --region us-east-1`
2. Confirm the workflow's IAM identity covers `iblai-lms-spa-pro` (the `iblai-*-spa-pro` wildcard in the existing policy should match — worth confirming).
3. In this workflow: `app_name: skills` → `app_name: lms`.
4. In `iblai/iblai-prod-images`: `lms=Image("…/iblai-skills-spa-pro", "0.35.0")` → `lms=Image("…/iblai-lms-spa-pro", "<initial version>")`. Tag and release.
5. Tag a release on `iblai/lms` so the new ECR repo gets at least one image.
6. Operators flip `RUN_LMS_SPA: true` + DNS for `lms.<base>`.

That sequence is independent of this PR. Cosmetic run-name first; ECR decoupling later if/when needed.

## Coordination

Part of a six-PR coordinated rename:

| Repo | PR | Purpose |
|---|---|---|
| `iblai-cli-ops` | [#1985](https://github.com/iblai/iblai-cli-ops/pull/1985) | 5.26.0: SKILLSAI → LMS namespace |
| `iblai-prod-images` | [#154](https://github.com/iblai/iblai-prod-images/pull/154) | 1.28.0: catalog `spa.skillsai` → `spa.lms` |
| `iblai/lms` (this PR) | — | run-name flip |

Companions earlier in the chain: `iblai-cli-ops` #1983 / #1984, `iblai-prod-images` #152 / #153, `iblai/hq` #1.

## Test plan

- [x] `git diff` shows exactly one line changed
- [x] `app_name: skills` confirmed unchanged (push target stays `iblai-skills-spa-pro`)
- [ ] On next tag push: Actions UI shows `'Build lms <tag>'` instead of `'Build skills <tag>'`; build/push still goes to `iblai-skills-spa-pro` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)