### PR TITLE
fix(e2e): copy pnpm-workspace.yaml into playwright image build

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
 # Copy package manifests from repo root (deps live here, not in e2e/)
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies (skip optional like electron, skip postinstall scripts)
 RUN pnpm install --frozen-lockfile --ignore-scripts --no-optional


### PR DESCRIPTION
## Summary

The `e2e/Dockerfile` only copied `package.json` and `pnpm-lock.yaml`, but the pnpm `overrides:` block (13 CVE pins — axios, hono, dompurify, qs, postcss, ws, etc.) lives in `pnpm-workspace.yaml`. Without that file inside the image, `pnpm@10` saw 13 overrides in the lockfile and 0 in the workspace config, and `--frozen-lockfile` aborted with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

The root `Dockerfile` already copies all three manifests (lines 14-16), which is why on a PR like #117 you see `build-app-image` ✅ and `build-playwright-image` ❌ in the same run against the same lockfile.

This has been latent since the e2e Dockerfile was added in v0.36.6 — it only surfaces when no cached image layer is available, which happens for `build-playwright-image` because the PR e2e workflow tags it `pr-<num>-<sha>` and forces a fresh build every run.

## Diff

```diff
- COPY package.json pnpm-lock.yaml ./
+ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
```

No lockfile regeneration needed — lockfile and workspace overrides are already in sync.

## Test plan

- [ ] CI: `build-playwright-image` succeeds on this PR
- [ ] Confirm full `PR E2E Tests (Required)` workflow runs through to `run-tests`
- [ ] Once merged, retrigger CI on #117 to unblock that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)