### PR TITLE
fix(docker): install Node 25.3.0 from official tarball — n package security-held on npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /app
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-# Install Node 25.3.0 via n
-RUN npm install -g n && n 25.3.0 && hash -r
+# Install Node 25.3.0 (download official binary; the `n` npm package was
+# replaced by a security-holding placeholder and no longer works)
+RUN wget -qO- https://nodejs.org/dist/v25.3.0/node-v25.3.0-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 \
+    && node --version
 
 # Enable Corepack and activate pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate


### PR DESCRIPTION
## Why builds are failing

Every `Docker Build` run since today fails at `Dockerfile:8` with:

```
/bin/sh: 1: n: not found
ERROR: ... exit code: 127
```

Root cause is on the npm registry, not in this repo: the [`n` package](https://www.npmjs.com/package/n) was replaced with an empty **"security holding package"** (`n@0.0.1-security`, published 2026-06-09 17:27 UTC — two hours before the first failing run). `npm install -g n` now installs a placeholder that ships no `n` binary, so `n 25.3.0` can never run. Last green build was `skills-v0.39.0` on 2026-06-08; `skills-v0.39.1` / `skills-v0.39.2` failed today with no Dockerfile change.

## Fix

Replace the `n` install with a direct download of the official nodejs.org dist tarball into `/usr/local` — which is exactly what `n` did internally, and the same pattern the alpine runner stage already uses for the musl build. No more dependency on a third-party npm package resolving `latest` at build time.

**Why not `FROM node:25.3.0`?** Node 25 dropped Corepack from its distribution — the official `node:25` image and tarballs no longer include it, which would break the `corepack enable` step on line 13. The tarball overlay leaves `node:20`'s corepack binary in place, identical to how the previous `n`-based flow behaved.

## Notes for after merge

- The `Docker Build` workflow triggers on **tags** (`skills-v*`), so the failed versions need re-tagging from the fixed main (or cut `skills-v0.39.3`).
- The PR e2e workflow's path filter doesn't include `Dockerfile`, so CI on this PR won't exercise the image build — the first tag push after merge is the real verification.
- Security follow-up: if `n` was hijacked (consistent with this month's npm supply-chain wave), the malicious version window is unknown — builds on June 7–8 installed `n@latest` in CI. Worth rotating secrets reachable by the docker-build job if an advisory lands naming that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)