### PR TITLE
chore: bumped iblai-js version to 1.18.1

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -87,6 +87,6 @@ export const config = {
       getEnv('NEXT_PUBLIC_ENABLE_STUDIO_HEADER_MENU', 'true') !== 'false',
     staticCopyrightEnabled: () => getEnv('NEXT_PUBLIC_ENABLE_STATIC_COPYRIGHT', 'false') === 'true',
     defaultSupportPhoneNumber: () =>
-      getEnv('NEXT_PUBLIC_DEFAULT_SUPPORT_PHONE_NUMBER', '(571) 293-0242'),
+      getEnv('NEXT_PUBLIC_DEFAULT_SUPPORT_PHONE_NUMBER', '(571) 293-0242') || '(571) 293-0242',
   },
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@hookform/resolvers": "3.10.0",
     "@iblai/agent-ai": "2.6.1",
     "@iblai/iblai-api": "4.166.0-ai",
-    "@iblai/iblai-js": "1.17.25",
+    "@iblai/iblai-js": "1.18.1",
     "@livekit/components-react": "2.8.1",
     "@livekit/components-styles": "1.1.4",
     "@radix-ui/react-accordion": "1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 4.166.0-ai
         version: 4.166.0-ai
       '@iblai/iblai-js':
-        specifier: 1.17.25
-        version: 1.17.25(800c1b88cac12fc16e96b86da24143c6)
+        specifier: 1.18.1
+        version: 1.18.1(800c1b88cac12fc16e96b86da24143c6)
       '@livekit/components-react':
         specifier: 2.8.1
         version: 2.8.1(livekit-client@2.9.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
@@ -848,8 +848,8 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0
 
-  '@iblai/data-layer@1.7.5':
-    resolution: {integrity: sha512-0tCacexVFE3RbMBZh1+hLy/uS2jd10HfLdufT4xI8GxOx/h6r9K191p+ca0kYs68r+Q78yyOWX7rqv7ue3oi+w==}
+  '@iblai/data-layer@1.8.1':
+    resolution: {integrity: sha512-ju7wLZV+qKz+VG6yfbQE+kOFM4tMyfN/HVKvlTGJuX51hqqyWr/HE6TWZz+2MGOvvm7YhIXRsoWBBlofR24hLQ==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@reduxjs/toolkit': 2.7.0
@@ -860,8 +860,8 @@ packages:
   '@iblai/iblai-api@4.166.0-ai':
     resolution: {integrity: sha512-dY9Jv+CkXEyTxRsOQFay5YvYe8K2LSQluJJvtssGQV2RbrxPPzONaKfnhcyarDs7Ft35Xqk1fuErjhUwNG3OIg==}
 
-  '@iblai/iblai-js@1.17.25':
-    resolution: {integrity: sha512-4rIl/9kBpUyBd8iLVI/vFBgCM4EsEG2ul+I2nYIOFe1C/RUOhlvoCJyGfmjgTnkHrLhNGWs/M6AESQrjfdO4+A==}
+  '@iblai/iblai-js@1.18.1':
+    resolution: {integrity: sha512-etVVl+1tD1fGl+XcxP15+vfSD6iqWf0VNdusq9Eji+aBD8R9q2+QDEYK+/V0zxqtqXK5XB/ARjmTTr4x226p6A==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -882,16 +882,16 @@ packages:
       next:
         optional: true
 
-  '@iblai/mcp@1.5.8':
-    resolution: {integrity: sha512-OSb2gYXzfZItOFOnk/Lrw8yfv5oU4bLOzis07+XFGrA124DsNx21ymsHhv+nxbT08K2IpZ6nQDLSpOF+cdWGWQ==}
+  '@iblai/mcp@1.6.0':
+    resolution: {integrity: sha512-e2D3Q1w8KTvnfhzayCMH23dbSH3m8/sJYGsgB4cWFLBt+8VffByeLR3fm5yPG2+cnxHD4DMgL9zYCUXnVWFOxA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@iblai/web-containers@1.8.19':
-    resolution: {integrity: sha512-K0E+xGuzzE2mrX4JvQUObZRD/mZY0hAuePM9iNTxa2PSe/CVhOz0kXRjuuJxwLwoQHgdilxwqtUn7krVD93zHQ==}
+  '@iblai/web-containers@1.9.1':
+    resolution: {integrity: sha512-y3F/FdqoISI6R61uEx/METlWM6/mzkq8osQHY1Z5G6W5TBm/+pRqW242royNuvtgPec/DzloVfyZc5SI6fp9aw==}
     engines: {node: 25.3.0}
     peerDependencies:
-      '@iblai/data-layer': 1.7.5
+      '@iblai/data-layer': 1.8.1
       '@iblai/iblai-api': 4.166.0-ai
       '@iblai/web-utils': 1.10.11
       '@livekit/components-react': 2.8.1
@@ -8441,7 +8441,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@iblai/data-layer@1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+  '@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
@@ -8455,13 +8455,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@iblai/iblai-js@1.17.25(800c1b88cac12fc16e96b86da24143c6)':
+  '@iblai/iblai-js@1.18.1(800c1b88cac12fc16e96b86da24143c6)':
     dependencies:
-      '@iblai/data-layer': 1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/mcp': 1.5.8
-      '@iblai/web-containers': 1.8.19(d180150674afd9c856ce7eb18a8bc883)
-      '@iblai/web-utils': 1.10.11(@iblai/data-layer@1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/mcp': 1.6.0
+      '@iblai/web-containers': 1.9.1(174d1100950e946ec79ecfced0895ea6)
+      '@iblai/web-utils': 1.10.11(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-dialog': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.16.0
@@ -8491,7 +8491,7 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/mcp@1.5.8':
+  '@iblai/mcp@1.6.0':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
@@ -8499,11 +8499,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@iblai/web-containers@1.8.19(d180150674afd9c856ce7eb18a8bc883)':
+  '@iblai/web-containers@1.9.1(174d1100950e946ec79ecfced0895ea6)':
     dependencies:
-      '@iblai/data-layer': 1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.10.11(@iblai/data-layer@1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/web-utils': 1.10.11(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-accordion': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -8585,9 +8585,9 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/web-utils@1.10.11(@iblai/data-layer@1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@iblai/web-utils@1.10.11(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@iblai/data-layer': 1.7.5(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.8.1(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.16.0


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- chore: bumped iblai-js version to 1.18.1