### PR TITLE
ci: push release image to iblai-lms-spa (replaces iblai-skills-spa-pro)

### DIFF
--- a/.github/workflows/reusable-spa-docker-build.yml
+++ b/.github/workflows/reusable-spa-docker-build.yml
@@ -70,6 +70,9 @@ jobs:
             skills)
               echo "image_name=iblai-skills-spa-pro" >> $GITHUB_OUTPUT
               ;;
+            lms)
+              echo "image_name=iblai-lms-spa" >> $GITHUB_OUTPUT
+              ;;
             auth)
               echo "image_name=iblai-auth-spa-pro" >> $GITHUB_OUTPUT
               ;;

--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -31,7 +31,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/reusable-spa-docker-build.yml
     with:
-      app_name: skills
+      app_name: lms
       source_repo: ${{ github.repository }}
       source_ref: ${{ github.ref }}
       version: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## What

Points the **release** build at the new `iblai-lms-spa` ECR repo. New `v*` / `skills-v*` tags publish to `iblai-lms-spa` **only**:

- `765174860755.dkr.ecr.us-east-1.amazonaws.com/iblai-lms-spa:<version>`
- `765174860755.dkr.ecr.us-east-1.amazonaws.com/iblai-lms-spa:latest`

Mirrors the same change just made for `iblai/os` → `iblai-os-spa`.

## Backward compatibility

Existing `iblai-skills-spa-pro` tags stay in ECR and remain pullable, so clients still referencing the old repo keep working on the images already published there. They simply won't receive new releases under the old name — new versions go to `iblai-lms-spa`.

## Changes

- **`trigger-docker-build.yml`** — `app_name: skills` → `lms` (`run-name` is already "Build lms").
- **`reusable-spa-docker-build.yml`** — new `lms)` case → `iblai-lms-spa`.

No build-arg change is needed: `skills` never received the mentor-only `NEXT_IMAGE_PATTERNS` / `SENTRY_AUTH_TOKEN` build args, and `lms` doesn't either — build behavior is identical.

## Notes

- The `iblai-lms-spa` ECR repo already exists in account `765174860755` (us-east-1), so no missing-repo push failure.
- **Out of scope:** the OCIR PR/E2E test images in `pr-e2e-tests.yml` (`iblai-skills-spa-pro` / `ibl-skills-playwright`) are unchanged — different registry (OCIR), coupled to the stg1 deploy path.
- The `skills-v*` tag trigger is left in place (still fires the build); only the image target changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
