### PR TITLE
ci: grant contents:write to macOS DMG release caller

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -30,7 +30,11 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read # build-only: only uploads a CI artifact (bump to write when release mode is enabled)
+  # Must be at least as permissive as the reusable workflow it calls, which
+  # declares `contents: write` (GitHub validates caller >= callee permissions at
+  # parse time, regardless of the release step's runtime `if:` guard). Only
+  # actually exercised when release_tag is set; harmless in build-only mode.
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
## Problem

The `Release macOS DMG` workflow failed to validate:

> Invalid workflow file: `.github/workflows/release-macos-dmg.yml#L36`
> The workflow is requesting `contents: write`, but is only allowed `contents: read`.

The caller (`release-macos-dmg.yml`) declared `permissions: contents: read`, but it invokes the reusable `reusable-release-macos-dmg.yml`, which declares `contents: write` (needed to upload the DMG asset to a Release).

GitHub validates that a caller grants **at least** the reusable workflow's permissions **at parse time** — regardless of the release step's runtime `if: ${{ inputs.release_tag != '' }}` guard. So the read-only caller can never invoke this reusable, even in build-only mode.

## Fix

Bump the caller to `contents: write`, matching the reusable workflow (and the equivalent mentorai caller). The write scope is only exercised when `release_tag` is set; in the current build-only mode it goes unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)