### PR TITLE
ci: update stg1 E2E host IP → 98.82.66.78 (old box unreachable)

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
       browsers: 'chrome'
       workers: '3'
       registry-type: 'ocir'
-      ec2-host: '32.196.111.179'
+      ec2-host: '98.82.66.78'
       ec2-user: 'ubuntu'
       runs-on: iblai-stg-runner
       ec2-commands: >-


### PR DESCRIPTION
Stg1 E2E host IP changed; `pr-e2e-tests.yml` hardcodes the old one as `ec2-host`, so `run-tests / ec2-ssh` times out (`Connection timed out` to 32.196.111.179). Update `32.196.111.179` → `98.82.66.78`. Companion to iblai/os#348 and the iblai-web-frontend update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)