### PR TITLE
ci(e2e): prune docker images on stg deploy (fix 'no space left on device')

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -100,6 +100,7 @@ jobs:
         cd /ibl/app/ibl-spa/skills &&
         sed -i 's|image: .*|image: ${{ needs.build-app-image.outputs.image-uri }}|' docker-compose.yml &&
         docker compose down &&
+        docker image prune -af &&
         docker compose up -d
 
   # ============================================================


### PR DESCRIPTION
Same fix as iblai/os#351. The skills E2E `ec2-commands` pulls a fresh per-PR image onto the stg box (98.82.66.78) every run via `docker compose down && up -d` without pruning, so `/var/lib/docker` fills and `docker compose up -d` dies with `no space left on device`. Add `docker image prune -af` between `compose down` and `up -d` so the deploy self-cleans (running services keep their images) and the box never accumulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)