### PR TITLE
feat(security): nonce-based CSP middleware via @iblai/iblai-js/security

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { applyCsp } from '@iblai/iblai-js/security/next';
 
 // Server components don't have direct access to the request URL/pathname.
 // Forward the pathname as a header so layouts can read it via `headers()` and
@@ -7,7 +8,11 @@ import { NextRequest, NextResponse } from 'next/server';
 export function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-pathname', request.nextUrl.pathname);
-  return NextResponse.next({ request: { headers: requestHeaders } });
+  // Attach the per-request, nonce-based Content-Security-Policy. Report-only by
+  // default (set CSP_MODE=enforce once violation reports are clean). applyCsp
+  // stamps the nonce onto these same request headers — preserving x-pathname —
+  // and returns the response carrying the CSP header.
+  return applyCsp(request, { requestHeaders });
 }
 
 export const config = {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@hookform/resolvers": "3.10.0",
     "@iblai/agent-ai": "2.6.1",
     "@iblai/iblai-api": "4.166.0-ai",
-    "@iblai/iblai-js": "1.26.8",
+    "@iblai/iblai-js": "1.27.1",
     "@livekit/components-react": "2.8.1",
     "@livekit/components-styles": "1.1.4",
     "@radix-ui/react-accordion": "1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 4.166.0-ai
         version: 4.166.0-ai
       '@iblai/iblai-js':
-        specifier: 1.26.8
-        version: 1.26.8(800c1b88cac12fc16e96b86da24143c6)
+        specifier: 1.27.1
+        version: 1.27.1(800c1b88cac12fc16e96b86da24143c6)
       '@livekit/components-react':
         specifier: 2.8.1
         version: 2.8.1(livekit-client@2.9.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
@@ -848,8 +848,8 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0
 
-  '@iblai/data-layer@1.9.6':
-    resolution: {integrity: sha512-6vDuK3kbMRVVCIGjahfXbLPtN2tnIYXwMO5o1YWlfX7qeYKVybUwPVBTBxiqCyB6wkhy/LhPAi17EXy7/LcVDQ==}
+  '@iblai/data-layer@1.9.7':
+    resolution: {integrity: sha512-cFQVESmMM+Zd1gxv8jJRIOwhyjQKgkZnrAPWPkbQkdItT0IhWSXW7T1ZjwlmFgdBlYJUoxtE989Uzeg84sTS3Q==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@reduxjs/toolkit': 2.7.0
@@ -860,8 +860,8 @@ packages:
   '@iblai/iblai-api@4.166.0-ai':
     resolution: {integrity: sha512-dY9Jv+CkXEyTxRsOQFay5YvYe8K2LSQluJJvtssGQV2RbrxPPzONaKfnhcyarDs7Ft35Xqk1fuErjhUwNG3OIg==}
 
-  '@iblai/iblai-js@1.26.8':
-    resolution: {integrity: sha512-bMO266oQATnd5ul0P61tCLR7ScXCZKampWSlnOGngO4UQiDAWR4EzhLn6sRSXyR0Jf5YQmW1KY5qydqvs4Tk8A==}
+  '@iblai/iblai-js@1.27.1':
+    resolution: {integrity: sha512-q3aReBd9zaKD9YhpCJAy8XHfQIg6nm581IFDo2WnFO7ITUr8IaOLZwOkR9c1MNFOQv0Pf1ftUDu5lqCtDCPRtQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -882,18 +882,18 @@ packages:
       next:
         optional: true
 
-  '@iblai/mcp@1.8.2':
-    resolution: {integrity: sha512-zUppU29ZO/nzs1X1seToym3MmgcSnqpVhKVCd4vEE+Y5chet/iL6Ym0XOFNeVIh8veEe4Ks4lA8h+BYK4kQ3rQ==}
+  '@iblai/mcp@1.8.3':
+    resolution: {integrity: sha512-3hmPUyfOaS07NUABSnrsyXSDzc/AROSJyUJmk4xSaCE7eMtBuIUXxfImPa04jUV76s9e8aU1ZaUbkmjLkAMyqQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@iblai/web-containers@1.15.4':
-    resolution: {integrity: sha512-opAcnqVJ/349mkjuHEPhq+ZQAw7lXGKVMagGYG7B2bovYyhp2P+2w+vt/5FZZ7wkaNUJq+bPGEEZy8lcf/2RyQ==}
+  '@iblai/web-containers@1.15.7':
+    resolution: {integrity: sha512-XiqomBavZ4xuBZJSIsvtygqIaOrUlk3gYyAsOp91lhjzy9aIdCXyoXD3NP5j1ZH/xsK7ReTT98GwjCxN4rzV1A==}
     engines: {node: 25.3.0}
     peerDependencies:
-      '@iblai/data-layer': 1.9.5
+      '@iblai/data-layer': 1.9.7
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.13.4
+      '@iblai/web-utils': 1.14.1
       '@livekit/components-react': 2.8.1
       '@radix-ui/react-dialog': ^1.1.7
       '@reduxjs/toolkit': 2.7.0
@@ -913,14 +913,15 @@ packages:
       sonner:
         optional: true
 
-  '@iblai/web-utils@1.13.5':
-    resolution: {integrity: sha512-E/9Xrm+kj6hNwkrkdVD3Hbx2RERoZAuXyM/vs1auMt6PFZFyPdGgTZQl/QEt3XlgpEgFO/iALVTDb1PovUDJUg==}
+  '@iblai/web-utils@1.14.1':
+    resolution: {integrity: sha512-SG3wcdrP91c73cGF4RaCIJpYdRMktsQop7dhfF2nsAxll2oRuuqKAeiPzZx3quPU5Ln1/mSV2vxrJi50DuSw0A==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@iblai/data-layer': ^1.1.2
       '@iblai/iblai-api': 4.166.0-ai
       '@tauri-apps/api': '*'
       '@tauri-apps/plugin-os': 2.3.2
+      next: '>=14'
       react: 19.1.0
       react-dom: 19.1.0
       sonner: ^2.0.0
@@ -928,6 +929,8 @@ packages:
       '@tauri-apps/api':
         optional: true
       '@tauri-apps/plugin-os':
+        optional: true
+      next:
         optional: true
       sonner:
         optional: true
@@ -8493,7 +8496,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@iblai/data-layer@1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+  '@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
@@ -8507,13 +8510,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@iblai/iblai-js@1.26.8(800c1b88cac12fc16e96b86da24143c6)':
+  '@iblai/iblai-js@1.27.1(800c1b88cac12fc16e96b86da24143c6)':
     dependencies:
-      '@iblai/data-layer': 1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/mcp': 1.8.2
-      '@iblai/web-containers': 1.15.4(8ecb358bed64a40c208267feeb997fc9)
-      '@iblai/web-utils': 1.13.5(@iblai/data-layer@1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/mcp': 1.8.3
+      '@iblai/web-containers': 1.15.7(44341db4cdc2d7490fb335f5e5dc5a0b)
+      '@iblai/web-utils': 1.14.1(@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(next@15.5.18(@babel/core@7.29.7)(@playwright/test@1.58.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-dialog': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.16.0
@@ -8543,7 +8546,7 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/mcp@1.8.2':
+  '@iblai/mcp@1.8.3':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
@@ -8551,11 +8554,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@iblai/web-containers@1.15.4(8ecb358bed64a40c208267feeb997fc9)':
+  '@iblai/web-containers@1.15.7(44341db4cdc2d7490fb335f5e5dc5a0b)':
     dependencies:
-      '@iblai/data-layer': 1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.13.5(@iblai/data-layer@1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/web-utils': 1.14.1(@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(next@15.5.18(@babel/core@7.29.7)(@playwright/test@1.58.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-accordion': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -8639,9 +8642,9 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/web-utils@1.13.5(@iblai/data-layer@1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@iblai/web-utils@1.14.1(@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.2.14)(next@15.5.18(@babel/core@7.29.7)(@playwright/test@1.58.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@iblai/data-layer': 1.9.6(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.9.7(@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.16.0
@@ -8657,6 +8660,7 @@ snapshots:
     optionalDependencies:
       '@tauri-apps/api': 2.11.0
       '@tauri-apps/plugin-os': 2.3.2
+      next: 15.5.18(@babel/core@7.29.7)(@playwright/test@1.58.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sonner: 1.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@types/react'


### PR DESCRIPTION
## What

Adds a per-request, **nonce-based Content-Security-Policy** by composing the shared `applyCsp` helper from `@iblai/iblai-js/security/next` into the app's existing middleware. Bumps `@iblai/iblai-js` `1.26.8 → 1.27.1` (latest published) to pick up the `./security/next` export.

## How

`middleware.ts` keeps forwarding `x-pathname` and now returns `applyCsp(request, { requestHeaders })` instead of `NextResponse.next(...)`. `applyCsp` stamps the per-request nonce onto the same request headers (so Next.js applies it to its own scripts) and sets the CSP response header. The policy: nonce + `'strict-dynamic'` script-src, `worker-src 'self' blob:` (Sentry Replay), ibl.ai + Google/Stripe/YouTube allowlists, `object-src 'none'`, `base-uri 'self'`.

The CSP itself lives in the SDK (unit-tested to 100%); this PR is just the app wiring + version bump.

## Rollout — ships Report-Only by default ⚠️

- Emits `Content-Security-Policy-Report-Only` (nothing is blocked). Flip to enforcing with **`CSP_MODE=enforce`** once violation reports are clean.
- **Ops:** remove any static `Content-Security-Policy` header set upstream (Nginx) on deploy — browsers intersect multiple CSP headers. Keep static HSTS / X-Content-Type-Options / Referrer-Policy in Nginx.

## Before enabling `enforce` (follow-ups, not blockers for report-only)

A pre-merge review surfaced these — all only matter at the enforce flip:
- **Wire a report sink:** set `CSP_REPORT_URI` (env) so violations are collected; today there's no sink, so the "flip once clean" gate can't be measured.
- **Extra origins:** built-ins cover `*.iblai.app` / `*.ibl.ai` / `*.ibl.network`; `next.config.mjs` also references `iblai.org` / `iblai.tech` deployments. Add those (and any edX/media iframe hosts) via `applyCsp(request, { connectSrc: [...], frameSrc: [...] })` before enforcing, or edX/analytics calls will break.
- **Framing policy:** the library omits `frame-ancestors` (embed mode). If this app should not be framable, pass `frameAncestors: 'self'` (or `'none'`).
- **Matcher:** consider `createCspMiddleware`'s `DEFAULT_CSP_MATCHER`, which additionally excludes prefetch/api/static (Next.js recommends excluding prefetch for nonce CSP).

## Verification

Local: typecheck ✓, lint ✓, unit tests ✓ (320 files / 2857 tests), changed-file coverage gate ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)