### PR TITLE
fix(ci): run the e2e gate on a hosted runner

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -42,7 +42,11 @@ jobs:
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-tests') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: iblai-stg-runner
+    # A label check has no reason to need a self-hosted runner. Depending on one puts a single
+    # point of failure in FRONT of everything else: if that runner is down, gate never starts,
+    # nothing downstream runs, and the e2e queue guard cannot help — it lives inside the e2e
+    # job, which is never reached. stg2-spa going offline this way stalled a PR for 2h.
+    runs-on: ubuntu-latest
     steps:
       - run: echo "run-tests label detected — proceeding"
 


### PR DESCRIPTION
One line. Removes a single point of failure sitting in **front** of the whole pipeline.

```diff
   gate:
-    runs-on: iblai-stg-runner
+    runs-on: ubuntu-latest
```

### Why
`gate` only checks a label and the fork guard — there is no reason for it to need a self-hosted runner. But because it does, **if that runner is down, `gate` never starts and nothing downstream runs.**

The queue guard added in the previous PR cannot help here: it lives inside the `e2e` job, which is never reached. So this failure mode has **no timeout and no diagnosis** — the PR simply sits.

That is not hypothetical. A self-hosted runner going offline exactly this way stalled `os#361` for **2 hours** on 2026-07-29 before the caller gave up with a bare `timed_out`.

`iblai-web-frontend` was already fixed when it hit this on its first auth run; this brings os and lms in line. Every other job in the file already runs on `ubuntu-latest`.

### The deeper cause, tracked separately
Neither e2e runner is managed by systemd — both are started with `nohup ./run.sh &`, so **a reboot leaves them dead until someone SSHes in**. That is what actually took stg2-spa offline. Installing the runner service (`svc.sh install`) is the durable fix and is being handled on the boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)