### PR TITLE
fix(ci): a skipped e2e is not a failure

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -297,5 +297,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if e2e did not pass
-        if: needs.e2e.result != 'success'
+        # Only a real FAILURE should redden this check. `skipped` means the PR was never
+        # labelled `run-tests`, which is the opt-in model working as designed — treating it
+        # as failure would make every unlabelled PR unmergeable once this is a required check.
+        if: needs.e2e.result == 'failure' || needs.e2e.result == 'cancelled'
         run: exit 1


### PR DESCRIPTION
A PR that simply does not opt in currently gets a **red** `PR E2E Tests (Required)` check.

```
no run-tests label → gate skipped → e2e skipped → summary: "skipped" != "success" → RED
```

### Why this is urgent
The moment `PR E2E Tests (Required)` is added as a **required status check**, **every unlabelled PR becomes unmergeable** — which breaks the whole opt-in model the `run-tests` label exists to provide.

Caught on `iblai-web-frontend#1955`, whose run went red at 15:51 purely because the label was absent. Nothing had actually failed.

### The fix
```diff
-        if: needs.e2e.result != "success"
+        if: needs.e2e.result == "failure" || needs.e2e.result == "cancelled"
```

| e2e result | before | after |
|---|---|---|
| success | green | green |
| failure | RED | RED |
| cancelled | RED | RED |
| **skipped** | **RED** ✗ | **green/neutral** ✓ |

This restores what the original OCI workflow did (`== "failure" || == "cancelled"`) — the rewrite tightened it to `!= "success"` and silently changed the semantics of not opting in.

os also keeps its `unit-tests` clause, widened the same way.

Applied to all three callers: `iblai/os`, `iblai/lms`, `iblai/iblai-web-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)