### PR TITLE
fix(pr-e2e): stop the dispatch live-lock and never lose a report

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -155,6 +155,7 @@ jobs:
         env:
           GH_TOKEN:   ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
           PR:         ${{ github.event.pull_request.number }}
+          DISPATCH_CONCLUSION: ${{ steps.dispatch.outputs.conclusion }}
           TARGET_ENV: ${{ steps.env.outputs.target }}
         run: |
           set -uo pipefail
@@ -193,16 +194,25 @@ jobs:
           # previously-pending one before it starts a single job — silently, with no diagnosis on the
           # PR. Three PRs labelled close together is enough to trigger it, and pinning everything to
           # stg1 made that routine. So: never dispatch while another run for this env is waiting.
+          # Counts EVERY pending pr-e2e run, deliberately — not just ones whose title mentions this
+          # caller's TARGET. Filtering on the title was a correctness bug: the central `run-name`
+          # renders the env the run will actually USE, which an operator override in
+          # iblai-deploy-ops can redirect. On 2026-08-04 every central title read "→ stg2" while
+          # every caller searched for "→ stg1", so the count was permanently 0 — each caller
+          # believed the slot was free, all of them dispatched, and they evicted one another in a
+          # live-lock: six dispatches for os#405, zero tests executed, no report. A caller cannot
+          # know the effective env, so it must never infer one. Conservative costs throughput,
+          # never correctness.
           wait_for_slot() {
             local i w
             for i in $(seq 1 240); do
-              w=$(gh run list -R "$OPS" --workflow=pr-e2e.yml --limit 20 --json status,displayTitle \
-                    --jq "[.[] | select((.status==\"queued\" or .status==\"pending\") and (.displayTitle|contains(\"→ ${TARGET}\")))] | length" 2>/dev/null || echo 0)
+              w=$(gh run list -R "$OPS" --workflow=pr-e2e.yml --limit 20 --json status \
+                    --jq '[.[] | select(.status=="queued" or .status=="pending")] | length' 2>/dev/null || echo 0)
               [ "${w:-0}" -eq 0 ] && return 0
-              [ $(( (i-1) % 10 )) -eq 0 ] && echo "[$(date -u +%H:%M:%SZ)] waiting for a free dispatch slot on ${TARGET} — ${w} run(s) already queued ahead"
+              [ $(( (i-1) % 10 )) -eq 0 ] && echo "[$(date -u +%H:%M:%SZ)] waiting for a free dispatch slot — ${w} pr-e2e run(s) already queued ahead"
               sleep 30
             done
-            echo "::error::no free dispatch slot on ${TARGET} after 2h"; return 1
+            echo "::error::no free dispatch slot after 2h"; return 1
           }
 
           do_dispatch() {
@@ -372,12 +382,19 @@ jobs:
           if [ ! -f /tmp/res/pr-e2e-result.json ]; then
             echo "::warning::could not download pr-e2e-result from run ${RUN_ID} — the comment will lack a report link. https://github.com/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}"
           fi
+          # A run that produced nothing must never erase a run that produced something: an evicted
+          # dispatch used to overwrite a real verdict with "unknown", destroying the only
+          # PR-visible link to a good report (os#405, 2026-08-04).
+          GH_TOKEN="$REPO_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("<!-- pr-e2e-report -->"))] | .[-1].body // empty' \
+            > /tmp/prev.md 2>/dev/null || : > /tmp/prev.md
+
           python3 - <<'PY' > /tmp/body.md
-          import json, pathlib
+          import json, os, pathlib, re
           p = pathlib.Path("/tmp/res/pr-e2e-result.json")
           d = json.loads(p.read_text()) if p.exists() else {}
-          v    = d.get("verdict") or "unknown"
-          icon = {"success": "OK", "failure": "FAILED", "cancelled": "cancelled"}.get(v, v)
+          v    = d.get("verdict") or os.environ.get("DISPATCH_CONCLUSION") or "unknown"
+          icon = {"success": "OK", "failure": "FAILED", "cancelled": "NOT RUN"}.get(v, v)
           rep  = d.get("report_url") or ""
           rows = [("result", f"**{icon}**")]
           if d.get("platform"):
@@ -393,8 +410,22 @@ jobs:
               out += [f"**[Full report, traces and screenshots]({rep})**", ""]
           out += ["| | |", "|---|---|"] + [f"| {k} | {val} |" for k, val in rows]
           if not rep:
-              out += ["", "_No report link - the run likely failed before the suite started."
-                          " Ask a maintainer to check the central pipeline._"]
+              if v in ("cancelled", "no_slot", "dispatch_failed"):
+                  out += ["", "**No tests ran.** This run was cancelled before the suite started —"
+                              " usually because another PR's run took the shared environment, or a"
+                              " newer commit/label superseded this one."
+                              " **This says nothing about your code.**", "",
+                          "Re-trigger it yourself: **remove the `run-tests` label and add it back**."
+                          " (Avoid *Re-run jobs* — that replays the old merge ref instead of"
+                          " recomputing it against current `main`.)"]
+              else:
+                  out += ["", "_No report link - the run likely failed before the suite started."
+                              " Ask a maintainer to check the central pipeline._"]
+              prev = pathlib.Path("/tmp/prev.md").read_text() if pathlib.Path("/tmp/prev.md").exists() else ""
+              m = re.search(r"\[Full report, traces and screenshots\]\((https?://[^)]+)\)", prev)
+              if m:
+                  out += ["", f"Last completed run for this PR: **[report]({m.group(1)})** —"
+                              " still valid unless this PR has changed since."]
           print("\n".join(out))
           PY
           cat /tmp/body.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Mirrors `iblai/os#413` (merged). Without it this repo still starts the live-lock that cost os#405 an afternoon.

## Why this repo matters even though os is fixed

The caller decided whether a dispatch slot was free by **string-matching the central run title**:

```bash
.displayTitle | contains("→ ${TARGET}")
```

That title renders the env the run will actually USE, which an operator override in `iblai-deploy-ops` can redirect. On 2026-08-04 every central title read `→ stg2` while every caller asked for `→ stg1` — **0 matches, permanently**. Each caller believed the slot was free, all dispatched, and GitHub (which keeps **one** pending run per concurrency group) cancelled whichever was waiting. The evicted caller retried and evicted the next.

**Six dispatches for os#405 in fifteen minutes. Zero tests executed. No report.**

os#413 fixed the os caller — but this repo dispatches into the **same** concurrency group, so an unfixed caller here still evicts os runs. The class is only closed when every caller is fixed.

## Three changes

1. **`wait_for_slot` counts every pending `pr-e2e` run** instead of inferring an env from a display string. A caller cannot know the effective env, so it must never try. Conservative: occasionally serializes two genuinely independent envs — throughput, never correctness.

2. **The summary stops discarding a conclusion it already has.** It rendered `unknown` despite the dispatch step knowing the run ended `cancelled`, then told the developer to *"ask a maintainer"* — for something they can fix themselves:

   > ### PR E2E - NOT RUN
   > **No tests ran.** … **This says nothing about your code.**
   > Re-trigger it yourself: **remove the `run-tests` label and add it back.** (Avoid *Re-run jobs* — that replays the old merge ref.)

3. **A run that tested nothing no longer erases a run that tested everything.** The sticky comment updates in place, so an evicted dispatch overwrote a real verdict. The previous report is now carried forward as *"last completed run for this PR"*, hedged because the PR may have moved on.

## Verification

YAML parses; the embedded python parses and was **executed** against the evicted-with-prior-report case, rendering exactly the block above. A normal run is byte-identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)