### PR TITLE
fix(pr-e2e): never infer which runner executes the dispatched run

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -269,19 +269,26 @@ jobs:
                 fi
               fi
               if [ "$started" = "0" ]; then
+                # Which runner executes this run is NOT knowable from the env the caller REQUESTED:
+                # an operator override (vars.PR_E2E_ENV_OVERRIDE) can redirect it to the other box.
+                # Matching a guessed "${TARGET}-spa" made a perfectly healthy run on the OTHER runner
+                # look like an offline one and killed it 62 minutes before its suite finished — the
+                # report was written and the PR still said "ask a maintainer" (os#407, 2026-08-04).
+                # Count activity on ANY self-hosted runner instead: if the fleet is executing anything,
+                # we are QUEUED, not orphaned. Correct wherever the run lands, override or not.
                 # An offline runner never appears executing ANY job anywhere; a merely BUSY one does.
                 # Elapsed time cannot tell them apart when one serialized runner handles ~74-min suites.
                 busy=$(for rid in $(gh run list -R "$OPS" --limit 10 --json databaseId --jq '.[].databaseId' 2>/dev/null); do
                          gh api "repos/$OPS/actions/runs/$rid/jobs" \
                            --jq '.jobs[] | select(.status=="in_progress") | .runner_name // empty' 2>/dev/null
-                       done | grep -cx "$RUNNER" || true)
+                       done | grep -cvE '^(GitHub Actions|$)' || true)
                 if [ "${busy:-0}" -gt 0 ]; then
                   strikes=0
                 else
                   strikes=$((strikes + 1))
-                  if [ "$strikes" -ge 30 ]; then
+                  if [ "$strikes" -ge 60 ]; then
                     CONCLUSION=runner_unavailable
-                    echo "::error::${RUNNER} has been idle for 15 min while this run stayed queued — the runner is offline or not accepting jobs. https://github.com/$OPS/actions/runs/${RUN_ID}"
+                    echo "::error::no self-hosted runner has executed ANY job for 30 min while this run stayed queued — the runner fleet is offline or not accepting jobs. https://github.com/$OPS/actions/runs/${RUN_ID}"
                     return 1
                   fi
                 fi
@@ -410,17 +417,13 @@ jobs:
               out += [f"**[Full report, traces and screenshots]({rep})**", ""]
           out += ["| | |", "|---|---|"] + [f"| {k} | {val} |" for k, val in rows]
           if not rep:
-              if v in ("cancelled", "no_slot", "dispatch_failed"):
-                  out += ["", "**No tests ran.** This run was cancelled before the suite started —"
-                              " usually because another PR's run took the shared environment, or a"
-                              " newer commit/label superseded this one."
-                              " **This says nothing about your code.**", "",
-                          "Re-trigger it yourself: **remove the `run-tests` label and add it back**."
-                          " (Avoid *Re-run jobs* — that replays the old merge ref instead of"
-                          " recomputing it against current `main`.)"]
-              else:
-                  out += ["", "_No report link - the run likely failed before the suite started."
-                              " Ask a maintainer to check the central pipeline._"]
+              out += ["", f"**No test report was produced** (result: `{v}`). The run did not finish a"
+                          " suite — usually because another PR's run took the shared environment, a newer"
+                          " commit/label superseded this one, or it was abandoned before completing."
+                          " **This says nothing about your code.**", "",
+                      "Re-trigger it yourself: **remove the `run-tests` label and add it back**."
+                      " (Avoid *Re-run jobs* — that replays the old merge ref instead of"
+                      " recomputing it against current `main`.)"]
               prev = pathlib.Path("/tmp/prev.md").read_text() if pathlib.Path("/tmp/prev.md").exists() else ""
               m = re.search(r"\[Full report, traces and screenshots\]\((https?://[^)]+)\)", prev)
               if m:


### PR DESCRIPTION
**Permanent fix for the class that killed os#407** — a healthy run abandoned 62 minutes before its suite finished, with the PR told to "ask a maintainer" while a perfectly good report existed.

## Root cause: the caller INFERS what it should OBSERVE

```bash
RUNNER="${TARGET}-spa"      # derived from the env the caller ASKED for
...
done | grep -cx "$RUNNER"   # counts activity on a GUESSED runner
```

An operator override can redirect the run to the other box. Then the caller watches an idle `stg1-spa` while the work happens on `stg2-spa`, concludes the runner is offline, and **kills a healthy run**.

Replayed against the real os#407 data:

```
observed in_progress runners:  stg2-spa, GitHub Actions 1000093461

OLD  grep -cx "stg1-spa"           -> 0   => "idle" => KILLS the run
NEW  grep -cvE "^(GitHub Actions|$)" -> 1   => fleet alive => keeps waiting
genuinely offline fleet           -> 0   => still reports offline correctly
```

**This is the same root cause as the dispatch live-lock** (`wait_for_slot` parsing the run title). I fixed that one and missed this second instance of the identical pattern. Hence a sweep of every use of `TARGET`/`RUNNER`, not another point fix.

## Changes

1. **Liveness counts ANY self-hosted runner**, never a guessed name. If the fleet is executing anything, we are QUEUED, not orphaned — correct wherever the run lands, override or not.
2. **Longer margin** before declaring the fleet dead, and the error message no longer names a runner it only guessed at.
3. **The summary drops its conclusion whitelist.** `runner_unavailable` fell through `("cancelled","no_slot","dispatch_failed")` to the old "ask a maintainer" text. It now keys on *"was a report produced?"*, so **every** non-report conclusion gets the actionable message:

```
### PR E2E - runner_unavailable
**No test report was produced** (result: `runner_unavailable`). ... **This says nothing about your code.**
Re-trigger it yourself: remove the `run-tests` label and add it back.
Last completed run for this PR: [report](...)
```

Verified by executing the extracted renderer against `runner_unavailable`, `cancelled`, `timed_out` and `no_slot` — all four now render the actionable block.

## The rule this encodes

**The caller must never infer a fact about the dispatched run that it can observe.** Two incidents, one pattern: a guessed title (live-lock) and a guessed runner name (this). Anything derived from the caller's *requested* env is wrong the moment an override exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)