### PR TITLE
feat(ci): pass PR_E2E_LABEL_TOKEN so /retest can trigger a run

### DIFF
--- a/.github/workflows/pr-e2e-commands.yml
+++ b/.github/workflows/pr-e2e-commands.yml
@@ -50,3 +50,9 @@ jobs:
           comment_id:     ${{ github.event.comment.id }}
           repo_token:     ${{ secrets.GITHUB_TOKEN }}
           dispatch_token: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+          # REQUIRED for /retest. A label set with GITHUB_TOKEN raises NO events (GitHub's loop
+          # prevention), so the recycle succeeds and no test run ever starts — verified on os#381,
+          # where a recycle by github-actions[bot] triggered nothing while the same recycle by a
+          # human did. DEPLOY_OPS_DISPATCH_TOKEN is scoped to iblai-deploy-ops and 403s here, so
+          # this needs its own PAT with Issues + Pull requests write on this repo.
+          label_token: ${{ secrets.PR_E2E_LABEL_TOKEN }}


### PR DESCRIPTION
Wires `PR_E2E_LABEL_TOKEN` into the slash-command handler. Without it `/retest` cannot start a run.

## Why a separate token is unavoidable

A label set with `GITHUB_TOKEN` raises **no events** — GitHub's loop prevention. On os#381 the label was genuinely removed and re-added (both events in the PR timeline, actor `github-actions[bot]`), the API returned 200, and **no workflow fired**. The same recycle by a human minutes later did fire.

This rule has now bitten in three forms:

| | trigger that silently dies |
|---|---|
| (a) | release created with `GITHUB_TOKEN` → `on: release` |
| (b) | tag pushed with `GITHUB_TOKEN` → `on: push: tags` |
| **(c)** | **label set with `GITHUB_TOKEN` → `pull_request: labeled`** ← new |

`DEPLOY_OPS_DISPATCH_TOKEN` was tried and returns `403` — it is scoped to `iblai-deploy-ops`.

## Why not avoid the label instead

A PR's **required check** only attaches to `pull_request`-triggered runs. Dispatching the central pipeline directly would produce a report but leave the check stale, so the PR would stay unmergeable while looking tested. The label is the only path that refreshes the check, so it has to work.

## The token

Org secret, selected repos (`os`, `lms`, `iblai-web-frontend`), resource owner `iblai`, with **Issues** and **Pull requests** read/write — nothing else. Both are granted because a PR is not an issue: we already hit a 403 tonight where `issues: write` alone could not comment on a PR.

The action (`v1.4.0`) falls back to `dispatch_token` when this is unset, so merge order is not sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)