### PR TITLE
fix(tauri): resolve oneshot in iOS open_external_url (unblocks iOS build)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1395,7 +1395,7 @@ async fn open_external_url(app: AppHandle, url: String) -> Result<(), String> {
     println!("[ibl.ai] Opening external URL for OAuth: {}", url);
     #[cfg(target_os = "ios")]
     {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = tokio::sync::oneshot::channel();
         let url_for_main = url.clone();
         let app_handle = app.clone();
         app.run_on_main_thread(move || {


### PR DESCRIPTION
## Problem
`cargo tauri ios build` (target `aarch64-apple-ios`) fails to compile `src-tauri/src/lib.rs`:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `oneshot`
    --> src/lib.rs:1398   let (tx, rx) = oneshot::channel();
error[E0282]: type annotations needed   (x2, downstream fallout)
```

The iOS-only branch of `open_external_url` uses `oneshot::channel()` but nothing brings `oneshot` into scope. **This has been broken on `main` since the code was written** — iOS isn't built in CI (only the macOS DMG is), so it never got caught.

## Fix
`tokio` (with `features = ["full"]`) is already a dependency, so qualify it:
```rust
let (tx, rx) = tokio::sync::oneshot::channel();
```
`tokio::sync::oneshot`'s `Receiver::await` returns `Result<T, RecvError>`, which the existing `.unwrap_or_else(|_| Err(...))` already flattens correctly — no other changes needed.

## Verification
`cargo check --target aarch64-apple-ios --lib` → **Finished** (0 errors). Local `make tauri-ios-build` then archives + uploads to App Store Connect successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)