### PR TITLE
feat(deploy): immutable static hosting via AWS S3 + CloudFront

### DIFF
--- a/.github/workflows/reusable-spa-docker-build.yml
+++ b/.github/workflows/reusable-spa-docker-build.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build-and-push:
-    name: "Build & push ${{ inputs.app_name }} ${{ inputs.version }}"
+    name: 'Build & push ${{ inputs.app_name }} ${{ inputs.version }}'
     runs-on: oci-runner-1
     steps:
       - name: Clone source repo
@@ -96,6 +96,9 @@ jobs:
           VERSION: ${{ inputs.version }}
           IMAGE_NAME: ${{ steps.config.outputs.image_name }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Immutable static hosting (opt-in): the versioned CDN base. Empty
+          # unless NEXTJS_PUBLIC_ASSET_CDN is set, so it's a no-op otherwise.
+          ASSET_CDN: ${{ vars.NEXTJS_PUBLIC_ASSET_CDN }}
         run: |
           FULL_URI="$REGISTRY/$IMAGE_NAME:$VERSION"
 
@@ -114,6 +117,15 @@ jobs:
             if [ -n "$SENTRY_AUTH_TOKEN" ]; then
               BUILD_ARGS+=(--build-arg "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN")
             fi
+          fi
+
+          # When the asset CDN is configured, bake versioned /_next/* URLs
+          # (<cdn>/apps/<app>/<version>/…) into the image; the publish step below
+          # uploads this build's static to the matching S3 path.
+          if [ -n "$ASSET_CDN" ]; then
+            BUILD_ARGS+=(--build-arg "NEXT_PUBLIC_ASSET_CDN=$ASSET_CDN")
+            BUILD_ARGS+=(--build-arg "NEXT_PUBLIC_APP_NAME=${{ inputs.app_name }}")
+            BUILD_ARGS+=(--build-arg "APP_VERSION=$VERSION")
           fi
 
           docker build \
@@ -141,6 +153,49 @@ jobs:
 
           echo "Pushed: $FULL_URI"
           echo "Pushed: $REGISTRY/$IMAGE_NAME:latest"
+
+      # Immutable static hosting: publish this build's /_next/static + public to
+      # s3://<bucket>/apps/<app>/<version>/…, which CloudFront serves at
+      # <NEXTJS_PUBLIC_ASSET_CDN>. Opt-in — runs only when the CDN var is set, so
+      # it's a no-op for apps not using it. Requires the source ref to contain
+      # scripts/upload-static.sh.
+      - name: Publish static assets to S3 (immutable, versioned)
+        if: ${{ vars.NEXTJS_PUBLIC_ASSET_CDN != '' }}
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          VERSION: ${{ inputs.version }}
+          IMAGE_NAME: ${{ steps.config.outputs.image_name }}
+          APP_NAME: ${{ inputs.app_name }}
+          NEXT_PUBLIC_ASSET_CDN: ${{ vars.NEXTJS_PUBLIC_ASSET_CDN }}
+          S3_BUCKET: ${{ vars.NEXTJS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.NEXTJS_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.NEXTJS_S3_ACCESS_SECRET }}
+          AWS_REGION: ${{ secrets.NEXTJS_S3_AWS_REGION }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          FULL_URI="$REGISTRY/$IMAGE_NAME:$VERSION"
+
+          # aws CLI powers `aws s3 sync`; install to $HOME if the runner lacks it.
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "aws CLI not found — installing to \$HOME"
+            curl -sSL https://awscli.amazonaws.com/aws-cli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
+            unzip -q -o /tmp/awscliv2.zip -d /tmp
+            /tmp/aws/install -i "$HOME/.aws-cli" -b "$HOME/.local/bin" --update
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          aws --version
+
+          # Pull this build's static out of the image (no rebuild — assetPrefix
+          # only changes emitted URLs, not the files) and publish it.
+          mkdir -p .next
+          rm -rf .next/static public
+          cid=$(docker create "$FULL_URI")
+          docker cp "$cid:/app/.next/static" .next/static
+          docker cp "$cid:/app/public" public
+          docker rm "$cid"
+
+          bash scripts/upload-static.sh
 
       - name: Build summary
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,14 @@ RUN pnpm install --frozen-lockfile
 # Stage 1: Builder
 FROM base AS builder
 ARG APP_VERSION
+# Immutable static hosting: when NEXT_PUBLIC_ASSET_CDN is passed, /_next/* assets
+# are emitted under <cdn>/apps/<NEXT_PUBLIC_APP_NAME>/<APP_VERSION>/. Unset → the
+# build is unchanged (assets served from the app as before).
+ARG NEXT_PUBLIC_ASSET_CDN
+ARG NEXT_PUBLIC_APP_NAME
+ENV NEXT_PUBLIC_ASSET_CDN=$NEXT_PUBLIC_ASSET_CDN
+ENV NEXT_PUBLIC_APP_NAME=$NEXT_PUBLIC_APP_NAME
+ENV APP_VERSION=$APP_VERSION
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 COPY . .
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,108 @@
+# Immutable, deployment-ID static hosting
+
+Eliminates the version-skew problem (a browser on build A fetching a chunk from
+a node on build B → `ChunkLoadError`) that today forces us to drain LB backend
+sets during a blue/green deploy.
+
+## The idea
+
+Every build's `/_next/*` assets are published, **immutable**, to object storage
+under a per-release path and served from a CDN. The deployment ID is baked into
+the image at build time, so each node emits **self-consistent** absolute asset
+URLs for its own release:
+
+```
+a node running v0.101.0 emits:
+  <cdn>/apps/lms/0.101.0/_next/static/chunk-abc.js   ← the browser fetches this from the CDN
+```
+
+Because all releases' assets coexist in the CDN and are retained, node build
+skew can no longer break chunk loading — so nodes can be updated **rolling, in
+place**, with no full-pool drain. Nodes never fetch or look up assets: the ID is
+compile-time, the browser pulls from the CDN.
+
+Storage layout (bucket `apps/<app>/<version>/`):
+
+```
+apps/lms/0.101.0/_next/static/…      immutable, additive
+apps/lms/0.101.0/public/…            immutable, additive
+apps/lms/manifest/0.101.0.json       this build's record
+apps/lms/current.json                desired-live pointer (for GC + rollback tooling)
+```
+
+## What's in this repo (the app side — done)
+
+| Change                     | Effect                                                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next.config.ts`           | `generateBuildId` = release version; `assetPrefix` = `<NEXT_PUBLIC_ASSET_CDN>/apps/<app>/<version>` **when that env is set**, else unchanged. `crossOrigin: 'anonymous'`. |
+| `Dockerfile`               | Passes `NEXT_PUBLIC_ASSET_CDN`, `NEXT_PUBLIC_APP_NAME`, `APP_VERSION` into the build.                                                                                     |
+| `scripts/upload-static.sh` | Post-build: syncs `.next/static` + `public` to `apps/<app>/<version>/`, writes manifest + `current.json`.                                                                 |
+| `scripts/prune-static.sh`  | Retention/GC: keep newest `KEEP_LAST` + `current`, delete the rest. Dry-run by default.                                                                                   |
+
+**This is a no-op until `NEXT_PUBLIC_ASSET_CDN` is provided at build time.** With
+it unset (local dev, Tauri/offline export, and current prod) the app still serves
+its own static exactly as before — nothing breaks on merge.
+
+## What you need to do (infra + CI — manual)
+
+1. **AWS S3** — create a bucket (**any name** — the scripts read it from
+   `S3_BUCKET`; nothing assumes a particular one). Keep it **private** and reach
+   it via CloudFront OAC (a public-read bucket also works). Create an IAM
+   user/role for CI with `s3:PutObject` + `s3:ListBucket` on the bucket (add
+   `s3:DeleteObject` for the retention job) → access key/secret.
+2. **CloudFront** — distribution with **origin = the S3 bucket** (via an Origin
+   Access Control so the bucket stays private), alternate domain
+   **`assets.ibl.ai`** + an ACM cert **in us-east-1**. Cache `/_next/static/*`
+   forever (the objects already carry `Cache-Control: immutable`); attach a
+   **response-headers policy with CORS** (`Access-Control-Allow-Origin`) so
+   fonts/workers load cross-origin. Point the `assets.ibl.ai` DNS record at the
+   distribution. **No cache invalidation is ever needed** — this distribution
+   only serves immutable, version-namespaced static; HTML is served by the app
+   nodes, not CloudFront. Verify CloudFront serves keys **1:1** (no origin-path
+   rewrite) so `assets.ibl.ai/apps/lms/<v>/…` maps to bucket key `apps/lms/<v>/…`.
+3. **CI secrets/vars** (set on the build repo, `iblai/lms` → Settings → Secrets
+   and variables → Actions):
+
+   - **Variables**: `NEXTJS_PUBLIC_ASSET_CDN=https://assets.ibl.ai`,
+     `NEXTJS_S3_BUCKET=<your bucket>`.
+   - **Secrets**: `NEXTJS_S3_ACCESS_KEY`, `NEXTJS_S3_ACCESS_SECRET`,
+     `NEXTJS_S3_AWS_REGION`.
+
+   (`NEXT_PUBLIC_APP_NAME` is taken from the workflow's `app_name` — `lms`.
+   `S3_ENDPOINT` is only for a non-AWS S3-compatible store; leave it unset.)
+
+4. **Build + publish wiring — DONE** in `reusable-spa-docker-build.yml`: when
+   `NEXTJS_PUBLIC_ASSET_CDN` is set it passes the `NEXT_PUBLIC_ASSET_CDN` /
+   `NEXT_PUBLIC_APP_NAME` / `APP_VERSION` build-args, then a **Publish static
+   assets to S3** step extracts `.next/static` + `public` from the built image
+   and runs `scripts/upload-static.sh`. Gated on the variable, so it's a no-op
+   for every other app. (The step installs the aws CLI to `$HOME` if the runner
+   lacks it.) Nothing more to wire — just set the values in step 3.
+5. **Schedule retention**: a workflow running `scripts/prune-static.sh`
+   (`DRY_RUN=false`, `KEEP_LAST` ≥ your rollback horizon).
+6. **Switch the rollout** (ops `prod-service-update.sh`): once assets are on the
+   CDN, update nodes **rolling, in place** instead of draining a backend set.
+   Keep the LB swap only as an optional canary.
+7. **Server-Action skew** (the one residual): enable LB **sticky sessions**
+   during the rollout window and add a client `ChunkLoadError` → `location.reload()`
+   self-heal so a client briefly on an old build silently lands on the current one.
+
+## Rollback
+
+Images are tagged by release version and each is a self-contained deployment.
+Roll back = **re-deploy the previous image tag** (e.g. `0.100.1`). That image
+emits `0.100.1` asset URLs, and `0.100.1`'s assets are still in the bucket
+(retention), so the rollback is complete and instant — no rebuild, no re-upload,
+and skew-safe (both versions' assets coexist).
+
+⚠️ Rollback only works while the target version's assets are retained — keep
+`KEEP_LAST` (or an age policy) larger than how far back you'd ever roll.
+
+## App-specific cautions
+
+- **Tauri / offline (`output: 'export'`) builds must NOT set `NEXT_PUBLIC_ASSET_CDN`** —
+  they need self-contained relative assets.
+- **Service worker (`sw.js`) caching** must be reviewed against the new
+  cross-origin static origin before Phase 3.
+- If a release is ever **rebuilt with different content**, use
+  `DEPLOYMENT_ID=<version>-<sha8>` so it doesn't overwrite immutable assets.

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,6 +17,23 @@ const partnerHosts = () => {
   return raw ? raw.split(/[\s,]+/).filter(Boolean) : DEFAULT_PARTNER_HOSTS;
 };
 
+// Immutable-static CDN origin (e.g. assets.ibl.ai), when static assets are
+// served cross-origin from it. Derived from the SAME NEXT_PUBLIC_ASSET_CDN that
+// next.config.mjs bakes into assetPrefix, so the CSP and the emitted asset URLs
+// can't drift. Accepts a bare host or full URL; [] when unset (assets are
+// same-origin, so this is a no-op). The gap it closes is style-src + font-src
+// (script-src/img-src already allow it via strict-dynamic / `https:`).
+const assetCdnOrigin = (): string[] => {
+  let cdn = process.env.NEXT_PUBLIC_ASSET_CDN?.trim();
+  if (!cdn) return [];
+  if (!/^https?:\/\//i.test(cdn)) cdn = `https://${cdn}`;
+  try {
+    return [new URL(cdn).origin];
+  } catch {
+    return [];
+  }
+};
+
 // Server components don't have direct access to the request URL/pathname.
 // Forward the pathname as a header so layouts can read it via `headers()` and
 // branch on the current route (used to fetch the public platform-membership
@@ -31,13 +48,18 @@ export function middleware(request: NextRequest) {
   const partnerWs = partners
     .filter((h) => h.startsWith('https://'))
     .map((h) => `wss://${h.slice('https://'.length)}`);
+  const assetCdn = assetCdnOrigin();
   // Attach the per-request, nonce-based Content-Security-Policy. @iblai/iblai-js
   // @2.x ENFORCES by default; local dev is report-only via .env.development
   // (CSP_MODE=report-only). applyCsp stamps the nonce onto these same request
   // headers — preserving x-pathname — and returns the response with the header.
   return applyCsp(request, {
     requestHeaders,
-    connectSrc: [...IBL_ALT_HTTP, ...IBL_ALT_WS, ...partners, ...partnerWs],
+    // CDN-hosted CSS + fonts are cross-origin; style-src/font-src don't get the
+    // strict-dynamic/`https:` fallback, so allow the CDN origin explicitly.
+    styleSrc: assetCdn,
+    fontSrc: assetCdn,
+    connectSrc: [...IBL_ALT_HTTP, ...IBL_ALT_WS, ...partners, ...partnerWs, ...assetCdn],
     frameSrc: [...IBL_ALT_HTTP, ...partners], // edX + partner content in iframes
   });
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,41 @@
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+// ---------------------------------------------------------------------------
+// Immutable, deployment-ID-namespaced static hosting.
+//
+// deploymentId = the release version. When NEXT_PUBLIC_ASSET_CDN is set (web
+// build only) every /_next/* asset URL is prefixed with the CDN host under
+//   apps/<app>/<version>/
+// so all builds' immutable assets coexist in one shared store (S3 + CloudFront)
+// and node build skew can no longer cause ChunkLoadError. Unset → existing
+// basePath behavior, i.e. a no-op until the CDN env is provided.
+// ---------------------------------------------------------------------------
+const appName = process.env.NEXT_PUBLIC_APP_NAME || 'lms';
+const deploymentId =
+  process.env.DEPLOYMENT_ID || process.env.APP_VERSION || process.env.npm_package_version || 'dev';
+// Accept the CDN host with OR without a scheme ("assets.ibl.ai" or
+// "https://assets.ibl.ai") — Next requires assetPrefix to be an absolute URL,
+// so default a bare host to https://.
+let assetCdnBase = process.env.NEXT_PUBLIC_ASSET_CDN?.trim().replace(/\/+$/, '');
+if (assetCdnBase && !/^https?:\/\//i.test(assetCdnBase)) {
+  assetCdnBase = `https://${assetCdnBase}`;
+}
+const assetPrefix = assetCdnBase
+  ? `${assetCdnBase}/apps/${appName}/${deploymentId}`
+  : basePath
+    ? `${basePath}/`
+    : '';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath,
+  assetPrefix,
+  // Deterministic build ID = release version (stable across rebuilds; lets
+  // RSC/Server-Action version checks line up across a rolling fleet).
+  generateBuildId: async () => deploymentId,
+  // Assets are cross-origin once served from the CDN — emit crossorigin on the
+  // injected <script>/<link> tags.
+  crossOrigin: 'anonymous',
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/scripts/prune-static.sh
+++ b/scripts/prune-static.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# prune-static.sh — retention/GC for immutable per-deployment static assets.
+#
+# Keeps the newest KEEP_LAST deployments (by manifest upload time) plus whatever
+# apps/<app>/current.json points at, and deletes the rest's
+# apps/<app>/<version>/ tree + manifest. This is the ONLY thing that ever
+# removes published assets — everything else is additive — so it runs on a
+# schedule, defaults to a dry run, and always protects `current`.
+#
+# The keep window must exceed your rollback horizon: if you might roll back to
+# vX, vX's assets must still be here. Bump KEEP_LAST accordingly.
+#
+# Required env: S3_BUCKET, AWS_* (same as upload-static.sh)
+# Optional env:
+#   S3_ENDPOINT  only for S3-compatible non-AWS stores; unset = native AWS S3
+#   APP_NAME     default "os"
+#   KEEP_LAST    number of most-recent deployments to retain (default 10)
+#   DRY_RUN      "true" (DEFAULT) prints deletions without performing them;
+#                set "false" to actually delete
+
+set -euo pipefail
+
+: "${S3_BUCKET:?S3_BUCKET is required}"
+
+APP_NAME="${APP_NAME:-lms}"
+KEEP_LAST="${KEEP_LAST:-10}"
+DRY_RUN="${DRY_RUN:-true}"
+
+MANIFEST_PREFIX="s3://${S3_BUCKET}/apps/${APP_NAME}/manifest/"
+
+# S3_ENDPOINT only for non-AWS S3-compatible stores; array-free so the empty
+# case is safe under `set -u` on macOS's bash 3.2.
+aws_s3() {
+  if [[ -n "${S3_ENDPOINT:-}" ]]; then
+    aws s3 --endpoint-url "${S3_ENDPOINT}" "$@"
+  else
+    aws s3 "$@"
+  fi
+}
+
+echo "→ Retention for ${APP_NAME}: keep newest ${KEEP_LAST} + current (dry_run=${DRY_RUN})"
+
+# Version pointed at by current.json — always protected.
+CURRENT_VERSION="$(
+  aws_s3 cp "s3://${S3_BUCKET}/apps/${APP_NAME}/current.json" - 2>/dev/null \
+    | grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+)" || true
+echo "  current = ${CURRENT_VERSION:-<none>}"
+
+# All deployment versions, newest first (manifest object LastModified).
+ALL_VERSIONS="$(
+  aws_s3 ls "${MANIFEST_PREFIX}" \
+    | sort -r \
+    | awk '{print $NF}' \
+    | sed 's/\.json$//'
+)"
+
+[[ -z "${ALL_VERSIONS}" ]] && { echo "  no manifests found — nothing to do"; exit 0; }
+
+KEEP_SET=$'\n'"${CURRENT_VERSION}"$'\n'
+count=0
+while IFS= read -r v; do
+  [[ -z "$v" ]] && continue
+  count=$((count + 1))
+  if (( count <= KEEP_LAST )); then
+    KEEP_SET+="${v}"$'\n'
+  fi
+done <<< "${ALL_VERSIONS}"
+
+# Delete anything not in the keep set.
+while IFS= read -r v; do
+  [[ -z "$v" ]] && continue
+  if grep -qxF "$v" <<< "${KEEP_SET}"; then
+    continue
+  fi
+  echo "  ✖ prune ${APP_NAME} v${v}"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "     DRY_RUN: would delete apps/${APP_NAME}/${v}/ and manifest/${v}.json"
+  else
+    aws_s3 rm "s3://${S3_BUCKET}/apps/${APP_NAME}/${v}/" --recursive --only-show-errors
+    aws_s3 rm "s3://${S3_BUCKET}/apps/${APP_NAME}/manifest/${v}.json" --only-show-errors
+  fi
+done <<< "${ALL_VERSIONS}"
+
+echo "✅ Retention pass complete"

--- a/scripts/upload-static.sh
+++ b/scripts/upload-static.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# upload-static.sh — publish this build's immutable static assets to object
+# storage under apps/<app>/<version>/, then write the deployment manifest.
+#
+# Runs in CI AFTER `next build` (needs .next/static + public on disk and the
+# storage credentials — never bake creds into the image). Layout:
+#
+#   s3://<bucket>/apps/<app>/<version>/_next/static/...   <- immutable, additive
+#   s3://<bucket>/apps/<app>/<version>/public/...         <- immutable, additive
+#   s3://<bucket>/apps/<app>/manifest/<version>.json      <- this build's record
+#   s3://<bucket>/apps/<app>/current.json                 <- desired-live pointer
+#
+# The CDN (CloudFront) origin is the bucket, so a browser fetches
+#   <NEXT_PUBLIC_ASSET_CDN>/apps/<app>/<version>/_next/static/...   (assets.ibl.ai)
+# which mirrors these keys 1:1 (that same prefix is what next.config.ts bakes
+# into every emitted asset URL).
+#
+# Targets native AWS S3 (auth = an IAM access key/secret with s3:PutObject +
+# s3:ListBucket on the bucket). For an S3-compatible store instead (OCI Object
+# Storage, Cloudflare R2, MinIO), set S3_ENDPOINT to that endpoint and it's
+# passed through as --endpoint-url.
+#
+# Required env:
+#   S3_BUCKET         bucket name (e.g. ibl-static)
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION   IAM credentials
+#   VERSION           deployment id = release version (must match the built image)
+#
+# Optional env:
+#   S3_ENDPOINT       only for S3-compatible non-AWS stores; unset = native AWS S3
+#   APP_NAME          default "os"
+#   STATIC_DIR        default ".next/static"
+#   PUBLIC_DIR        default "public"
+#   GIT_SHA           recorded in the manifest (default "unknown")
+#   IMAGE_TAG         recorded in the manifest (default "$VERSION")
+#   UPDATE_CURRENT    "true" (default) also updates apps/<app>/current.json
+#   DRY_RUN           "true" prints the aws commands without running them
+
+set -euo pipefail
+
+: "${S3_BUCKET:?S3_BUCKET is required}"
+: "${VERSION:?VERSION (release version / deployment id) is required}"
+
+APP_NAME="${APP_NAME:-lms}"
+STATIC_DIR="${STATIC_DIR:-.next/static}"
+PUBLIC_DIR="${PUBLIC_DIR:-public}"
+GIT_SHA="${GIT_SHA:-unknown}"
+IMAGE_TAG="${IMAGE_TAG:-$VERSION}"
+UPDATE_CURRENT="${UPDATE_CURRENT:-true}"
+DRY_RUN="${DRY_RUN:-false}"
+BASE="s3://${S3_BUCKET}/apps/${APP_NAME}/${VERSION}"
+IMMUTABLE="public, max-age=31536000, immutable"
+
+# Only non-AWS S3-compatible stores need an explicit endpoint; native AWS S3
+# resolves it from AWS_REGION. (Kept array-free so the empty case is safe under
+# `set -u` on macOS's bash 3.2.)
+aws_s3() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY_RUN: aws s3 ${S3_ENDPOINT:+--endpoint-url ${S3_ENDPOINT}} $*"
+  elif [[ -n "${S3_ENDPOINT:-}" ]]; then
+    aws s3 --endpoint-url "${S3_ENDPOINT}" "$@"
+  else
+    aws s3 "$@"
+  fi
+}
+
+echo "→ Publishing ${APP_NAME} v${VERSION} static assets to ${BASE}"
+
+if [[ ! -d "${STATIC_DIR}" ]]; then
+  echo "✗ ${STATIC_DIR} not found — did 'next build' run?" >&2
+  exit 1
+fi
+
+# NOTE: no --delete. Uploads are additive and immutable; older deployments'
+# assets must survive for in-flight clients and rollback (see the retention job).
+echo "  → _next/static"
+aws_s3 sync "${STATIC_DIR}" "${BASE}/_next/static/" \
+  --only-show-errors --cache-control "${IMMUTABLE}"
+
+if [[ -d "${PUBLIC_DIR}" ]]; then
+  echo "  → public"
+  aws_s3 sync "${PUBLIC_DIR}" "${BASE}/public/" \
+    --only-show-errors --cache-control "${IMMUTABLE}"
+fi
+
+# ---- manifest -------------------------------------------------------------
+BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+ASSET_BASE="${NEXT_PUBLIC_ASSET_CDN:-<cdn-not-set>}/apps/${APP_NAME}/${VERSION}"
+MANIFEST="$(cat <<JSON
+{
+  "app": "${APP_NAME}",
+  "version": "${VERSION}",
+  "deploymentId": "${VERSION}",
+  "imageTag": "${IMAGE_TAG}",
+  "gitSha": "${GIT_SHA}",
+  "assetBase": "${ASSET_BASE}",
+  "builtAt": "${BUILT_AT}"
+}
+JSON
+)"
+
+TMP="$(mktemp)"
+trap 'rm -f "${TMP}"' EXIT
+printf '%s\n' "${MANIFEST}" > "${TMP}"
+
+echo "  → manifest/${VERSION}.json"
+aws_s3 cp "${TMP}" "s3://${S3_BUCKET}/apps/${APP_NAME}/manifest/${VERSION}.json" \
+  --only-show-errors --content-type application/json \
+  --cache-control "no-cache"
+
+if [[ "${UPDATE_CURRENT}" == "true" ]]; then
+  echo "  → current.json (desired-live pointer)"
+  aws_s3 cp "${TMP}" "s3://${S3_BUCKET}/apps/${APP_NAME}/current.json" \
+    --only-show-errors --content-type application/json \
+    --cache-control "no-cache"
+fi
+
+echo "✅ Published ${APP_NAME} v${VERSION}"
+echo "   assets:   ${ASSET_BASE}/_next/static/"
+echo "   manifest: s3://${S3_BUCKET}/apps/${APP_NAME}/manifest/${VERSION}.json"


### PR DESCRIPTION
## Summary

Brings the **immutable, deployment-ID static hosting** change (already shipped for os/mentorai) to skillsai (lms): every build's `/_next/*` assets are published immutably to `s3://<bucket>/apps/lms/<version>/…` and served from CloudFront (`assets.ibl.ai`), so node build skew can no longer cause `ChunkLoadError` and deploys can go rolling in-place.

**Fully opt-in — a no-op until `NEXTJS_PUBLIC_ASSET_CDN` is set.**

## Changes
- **`next.config.mjs`** — `generateBuildId` = release version; `assetPrefix` = `<cdn>/apps/<app>/<version>` when the CDN env is set (bare host auto-`https://`); `crossOrigin: 'anonymous'`.
- **`Dockerfile`** — `NEXT_PUBLIC_ASSET_CDN` / `NEXT_PUBLIC_APP_NAME` / `APP_VERSION` build-args.
- **`reusable-spa-docker-build.yml`** — passes those build-args + a **Publish static assets to S3** step (`docker cp` `.next/static` + `public` → `upload-static.sh`). Gated on the CDN var.
- **`scripts/upload-static.sh` + `prune-static.sh`** — publish + retention/GC (native AWS S3; `S3_ENDPOINT` optional).
- **`middleware.ts`** — allow the CDN origin in `style-src`/`font-src`/`connect-src` via `applyCsp` (the installed SDK already exposes these options), derived from the same `NEXT_PUBLIC_ASSET_CDN` so CSP + asset URLs can't drift.
- **`docs/DEPLOYMENT.md`** — runbook.

## Required to turn on (per-repo)
Set on `iblai/lms`: **Variables** `NEXTJS_PUBLIC_ASSET_CDN=https://assets.ibl.ai`, `NEXTJS_S3_BUCKET`; **Secrets** `NEXTJS_S3_ACCESS_KEY`, `NEXTJS_S3_ACCESS_SECRET`, `NEXTJS_S3_AWS_REGION`. (Shared CloudFront/bucket with os — just a different `apps/lms/` prefix.)

## Validation
Typecheck passes (confirms the `applyCsp` style/font options are type-valid against the installed SDK); assetPrefix + CSP-origin logic verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)