### PR TITLE
perf(bundle): deep-import lodash instead of the whole library

### DIFF
--- a/app/platform/[tenant]/course-content/[course_id]/__tests__/layout.test.tsx
+++ b/app/platform/[tenant]/course-content/[course_id]/__tests__/layout.test.tsx
@@ -29,13 +29,10 @@ vi.mock('sonner', () => ({
 }));
 
 // Mock lodash
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn(
-      (val: any) =>
-        !val || Object.keys(val).length === 0 || (Array.isArray(val) && val.length === 0),
-    ),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn(
+    (val: any) => !val || Object.keys(val).length === 0 || (Array.isArray(val) && val.length === 0),
+  ),
 }));
 
 // Mock lucide-react icons

--- a/app/platform/[tenant]/course-content/[course_id]/layout.tsx
+++ b/app/platform/[tenant]/course-content/[course_id]/layout.tsx
@@ -17,7 +17,7 @@ import Link from 'next/link';
 import { useCourseDetail } from '@/hooks/courses/use-course-detail';
 import { useCourseUserRoles } from '@/hooks/courses/use-course-user-roles';
 import { usePathname, useSearchParams } from 'next/navigation';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { toast } from 'sonner';
 import { useEdxIframe } from '@/hooks/courses/use-edx-iframe';
 import { AgentMode, EdxIframeContext } from '@/hooks/courses/edx-iframe-context';
@@ -168,7 +168,7 @@ export default function CourseContentLayout({
   }, [courseId]);
 
   useEffect(() => {
-    if (!_.isEmpty(course)) {
+    if (!isEmpty(course)) {
       if (!course?.mentor_hidden) {
         setCourseMentor(course.mentor_uuid || null);
       }
@@ -277,7 +277,7 @@ export default function CourseContentLayout({
     }
   }, [fullscreenToggleVisible]);
   useEffect(() => {
-    if (!_.isEmpty(courseOutline)) {
+    if (!isEmpty(courseOutline)) {
       const currentCourse = getUnitToIframe(courseOutline);
       setCurrentCourseInfo(currentCourse);
       const unitID = currentCourse?.id;

--- a/app/platform/[tenant]/courses/[course_id]/_components/syllabus-tab.tsx
+++ b/app/platform/[tenant]/courses/[course_id]/_components/syllabus-tab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Plus, Minus, Play } from 'lucide-react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { DefaultEmptyBox } from '@/components/default-empty-box';
 import { SkeletonMultiplier } from '@/components/skeleton-multiplier';
 import { SkeletonCourseSyllabus } from '@/components/skeleton-course-syllabus';
@@ -56,7 +56,7 @@ export function SyllabusTab({
                 {section.children?.map((lesson: any, lessonIndex: number) => (
                   <div
                     onClick={
-                      !_.isEmpty(lesson?.children)
+                      !isEmpty(lesson?.children)
                         ? () => handleOpenLesson(lesson?.children?.[0]?.id || null, true)
                         : () => {}
                     }

--- a/app/platform/[tenant]/courses/[course_id]/page.tsx
+++ b/app/platform/[tenant]/courses/[course_id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { Clock, Calendar, Globe, DollarSign } from 'lucide-react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { DefaultEmptyBox } from '@/components/default-empty-box';
 import { getRandomCourseImage } from '@/utils/helpers';
 import { config } from '@/lib/config';
@@ -76,7 +76,7 @@ export default function CourseDetailsPage() {
   // Course info is fetched once by `CourseDetailProvider` in the layout; the
   // page only reacts to the resulting `course` to wire up the mentor + syllabus.
   useEffect(() => {
-    if (!_.isEmpty(course)) {
+    if (!isEmpty(course)) {
       if (!course?.mentor_hidden) {
         setCourseMentor(course?.mentor_uuid || null);
       } else {

--- a/app/platform/[tenant]/discover/page.tsx
+++ b/app/platform/[tenant]/discover/page.tsx
@@ -6,7 +6,7 @@ import { CourseCardSkeleton } from '@/components/course-card-skeleton';
 import { useDiscover, ENROLLMENT_FACET_SLUG } from '@/hooks/discover/use-discover';
 import { SkeletonMultiplier } from '@/components/skeleton-multiplier';
 import { DefaultEmptyBox } from '@/components/default-empty-box';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { DiscoverContentCard } from '@/components/discover-content-card';
 import AccessiblePaginate from '@/components/ui/accessible-paginate';
@@ -141,7 +141,7 @@ export default function DiscoverPage() {
               </div>
               {filterDrawerOpen && <DiscoverFilterDrawer />}
               {/* Content Type Filter */}
-              {!_.isEmpty(selectedFacets) && (
+              {!isEmpty(selectedFacets) && (
                 <div className="mb-6 flex items-center gap-3">
                   {Object.keys(selectedFacets).map((selectedFacet: string, index: number) => {
                     if (selectedFacets?.[selectedFacet]?.length === 0) {

--- a/app/platform/[tenant]/pathways/[pathway_id]/page.tsx
+++ b/app/platform/[tenant]/pathways/[pathway_id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Image from 'next/image';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { toast } from 'sonner';
 
 import { PathwayCompletionResponse } from '@iblai/iblai-api';
@@ -283,7 +283,7 @@ export default function PathwayDetailPage() {
                   </button>
                 )}
 
-                {!_.isEmpty(pathwayCompletion) && (
+                {!isEmpty(pathwayCompletion) && (
                   <div className="space-y-2 rounded-lg border border-gray-200 bg-white p-4">
                     <div className="flex justify-between text-sm">
                       <span className="text-gray-600">Progress</span>

--- a/app/platform/[tenant]/profile/skills/__tests__/page.test.tsx
+++ b/app/platform/[tenant]/profile/skills/__tests__/page.test.tsx
@@ -11,12 +11,10 @@ vi.mock('lucide-react', () => ({
 }));
 
 // Mock lodash
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn(
-      (val: any) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
-    ),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn(
+    (val: any) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
+  ),
 }));
 
 // Mock useProfileSkills

--- a/app/platform/[tenant]/programs/[program_id]/__tests__/page.test.tsx
+++ b/app/platform/[tenant]/programs/[program_id]/__tests__/page.test.tsx
@@ -171,13 +171,11 @@ vi.mock('lucide-react', () => {
   };
 });
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: (val: any) =>
-      val == null ||
-      (Array.isArray(val) && val.length === 0) ||
-      (typeof val === 'object' && Object.keys(val).length === 0),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: (val: any) =>
+    val == null ||
+    (Array.isArray(val) && val.length === 0) ||
+    (typeof val === 'object' && Object.keys(val).length === 0),
 }));
 
 vi.mock('dayjs', () => {

--- a/app/platform/[tenant]/programs/[program_id]/page.tsx
+++ b/app/platform/[tenant]/programs/[program_id]/page.tsx
@@ -14,7 +14,7 @@ import {
   Save,
   X,
 } from 'lucide-react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { useDispatch } from 'react-redux';
@@ -1081,7 +1081,7 @@ export default function ProgramDetailPage() {
                   </button>
                 )}
 
-                {!_.isEmpty(programCompletion) && (
+                {!isEmpty(programCompletion) && (
                   <div className="space-y-2 rounded-lg border border-gray-200 bg-white p-4">
                     <div className="flex justify-between text-sm">
                       <span className="text-gray-600">Progress</span>

--- a/components/__tests__/chat-button.test.tsx
+++ b/components/__tests__/chat-button.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { renderHook } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
+import isEmpty from 'lodash/isEmpty';
 
 vi.mock('@/utils/helpers', () => ({
   getTenant: vi.fn(() => 'test-tenant'),
@@ -50,12 +51,10 @@ vi.mock('next/image', () => ({
 
 vi.mock('@iblai/agent-ai', () => ({}));
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn(
-      (val) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
-    ),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn(
+    (val) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
+  ),
 }));
 
 import { ChatButton, ChatContext, useChatState } from '../chat-button';
@@ -292,8 +291,7 @@ describe('ChatButton', () => {
   });
 
   it('handles mentor with no default metadata', async () => {
-    const _ = await import('lodash');
-    vi.mocked(_.default.isEmpty).mockReturnValue(false);
+    vi.mocked(isEmpty).mockReturnValue(false);
     mockGetMentors.mockReturnValue(
       makeMentorResult([
         { unique_id: 'mentor-1', metadata: {} },

--- a/components/__tests__/course-agent-chat.test.tsx
+++ b/components/__tests__/course-agent-chat.test.tsx
@@ -57,14 +57,13 @@ vi.mock('@/features/mentor', () => ({
   })),
 }));
 
-vi.mock('lodash', () => {
+vi.mock('lodash/isEmpty', () => {
   const isEmpty = (val: any) =>
     val == null ||
     (Array.isArray(val)
       ? val.length === 0
       : typeof val === 'object' && Object.keys(val).length === 0);
-  const lodash = { isEmpty };
-  return { default: lodash, isEmpty };
+  return { default: isEmpty };
 });
 
 const defaultContextValue = {

--- a/components/__tests__/course-lesson-navigator.test.tsx
+++ b/components/__tests__/course-lesson-navigator.test.tsx
@@ -7,12 +7,10 @@ vi.mock('lucide-react', () => ({
   ChevronRight: (props: any) => <span data-testid="chevron" {...props} />,
 }));
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn(
-      (val) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
-    ),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn(
+    (val) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
+  ),
 }));
 
 import { CourseLessonNavigator } from '../course-lesson-navigator';

--- a/components/__tests__/credential-detail-modal.test.tsx
+++ b/components/__tests__/credential-detail-modal.test.tsx
@@ -23,10 +23,8 @@ vi.mock('dayjs', () => {
   return { default: dayjs };
 });
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: (obj: any) => !obj || Object.keys(obj).length === 0,
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: (obj: any) => !obj || Object.keys(obj).length === 0,
 }));
 
 import { CredentialDetailModal } from '../credential-detail-modal';

--- a/components/__tests__/profile-info-cards.test.tsx
+++ b/components/__tests__/profile-info-cards.test.tsx
@@ -42,10 +42,8 @@ vi.mock('../skeleton-multiplier', () => ({
   ),
 }));
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn((val) => !val || Object.keys(val).length === 0),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn((val) => !val || Object.keys(val).length === 0),
 }));
 
 import { ProfileInfoCards } from '../profile-info-cards';

--- a/components/course-agent-chat.tsx
+++ b/components/course-agent-chat.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Loader2, SquarePen } from 'lucide-react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { toast } from 'sonner';
 import { useTenantMetadata } from '@iblai/iblai-js/web-utils';
 // @ts-ignore
@@ -51,7 +51,7 @@ export function CourseAgentChat() {
           username: getUserName(),
           query: DEFAULT_MENTOR_NAME,
         });
-        if (_.isEmpty(response?.data?.results)) {
+        if (isEmpty(response?.data?.results)) {
           throw new Error('No mentors found');
         }
         const mentor =

--- a/components/course-lesson-navigator.tsx
+++ b/components/course-lesson-navigator.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useContext } from 'react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { ChevronRight } from 'lucide-react';
 import { CourseOutlineContext } from '@/contexts/course-outline-context';
 import { EdxIframeContext } from '@/hooks/courses/edx-iframe-context';
@@ -10,7 +10,7 @@ import useCourseNavigator from '@/hooks/courses/useCourseNavigator';
 export const CourseLessonNavigator = ({ className }: { className?: string }) => {
   const { courseOutline, courseID } = useContext(EdxIframeContext);
   const { selectLesson, currentUnitID } = useContext(CourseOutlineContext);
-  const hasOutline = !_.isEmpty(courseOutline) && !!courseID;
+  const hasOutline = !isEmpty(courseOutline) && !!courseID;
   const { navigator } = useCourseNavigator(
     hasOutline ? courseOutline : ({ children: [] } as any),
     currentUnitID || courseID || '',

--- a/components/credential-detail-modal.tsx
+++ b/components/credential-detail-modal.tsx
@@ -5,7 +5,7 @@ import { useState, useRef, useEffect } from 'react';
 import { CustomAssertion } from '../types/credentials';
 import { CREDENTIAL_DEFAULT_IMG } from '@/constants/assets';
 import dayjs from 'dayjs';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { getRandomCourseImage, inBrowserPrint } from '@/utils/helpers';
 
 interface CredentialDetailModalProps {
@@ -93,7 +93,7 @@ export function CredentialDetailModal({ credential, onClose }: CredentialDetailM
             </p>
           </div>
           {/* Course Section with Image */}
-          {!_.isEmpty(credential?.course) && (
+          {!isEmpty(credential?.course) && (
             <div className="mb-6 overflow-hidden rounded-lg border border-gray-200">
               <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
                 <h3 className="text-md flex items-center gap-2 font-medium text-gray-700">

--- a/components/edx-iframe/__tests__/timed-exam.test.tsx
+++ b/components/edx-iframe/__tests__/timed-exam.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { EdxIframeContext } from '@/hooks/courses/edx-iframe-context';
 
 const mockUpdateExamAttempt = vi.fn();
@@ -15,15 +15,13 @@ vi.mock('@iblai/iblai-js/data-layer', () => ({
   useLazyGetExamInfoQuery: vi.fn(() => [mockGetExamInfo]),
 }));
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn((val: any) => {
-      if (val === null || val === undefined) return true;
-      if (typeof val === 'object' && !Array.isArray(val)) return Object.keys(val).length === 0;
-      if (Array.isArray(val)) return val.length === 0;
-      return false;
-    }),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn((val: any) => {
+    if (val === null || val === undefined) return true;
+    if (typeof val === 'object' && !Array.isArray(val)) return Object.keys(val).length === 0;
+    if (Array.isArray(val)) return val.length === 0;
+    return false;
+  }),
 }));
 
 import { TimedExam } from '../timed-exam';
@@ -106,7 +104,7 @@ describe('TimedExam', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     // Re-apply lodash mock implementation
-    vi.mocked(_.isEmpty).mockImplementation((val: any) => {
+    vi.mocked(isEmpty).mockImplementation((val: any) => {
       if (val === null || val === undefined) return true;
       if (typeof val === 'object' && !Array.isArray(val)) return Object.keys(val).length === 0;
       if (Array.isArray(val)) return val.length === 0;
@@ -559,7 +557,7 @@ describe('TimedExam', () => {
 
   it('handles exam with no active_attempt', () => {
     // When both attempt and active_attempt are empty, should show ready-to-start UI
-    vi.mocked(_.isEmpty).mockReturnValue(true);
+    vi.mocked(isEmpty).mockReturnValue(true);
     const examWithNoActive = {
       ...noAttemptExamInfo,
       active_attempt: null,

--- a/components/edx-iframe/edx-iframe.tsx
+++ b/components/edx-iframe/edx-iframe.tsx
@@ -2,7 +2,7 @@ import { EdxIframeContext } from '@/hooks/courses/edx-iframe-context';
 import { useContext, useEffect, useState, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useEdxIframe } from '@/hooks/courses/use-edx-iframe';
 import { Loader2 } from 'lucide-react';
 import { useDebouncedCallback } from 'use-debounce';
@@ -43,7 +43,7 @@ export const EdxIframe = () => {
   const [getExamInfo] = useLazyGetExamInfoQuery();
 
   const handleLoadCourse = useDebouncedCallback(() => {
-    if (!_.isEmpty(courseOutline)) {
+    if (!isEmpty(courseOutline)) {
       setExamInfo(null);
       setCurrentlyInExamSubsection(false);
       setFetchingIframeData(true);
@@ -186,7 +186,7 @@ export const EdxIframe = () => {
           )}
         >
           {examInfo && <TimedExam />}
-          {(!examInfo || (examInfo?.exam && !_.isEmpty(examInfo?.exam?.attempt))) && (
+          {(!examInfo || (examInfo?.exam && !isEmpty(examInfo?.exam?.attempt))) && (
             <iframe
               ref={iframeRef}
               src={iframeUrl}

--- a/components/edx-iframe/timed-exam.tsx
+++ b/components/edx-iframe/timed-exam.tsx
@@ -1,7 +1,7 @@
 import { EdxIframeContext } from '@/hooks/courses/edx-iframe-context';
 import { useContext, useState, useEffect } from 'react';
 import { Clock, AlertCircle } from 'lucide-react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import {
   // @ts-ignore
   useUpdateExamAttemptMutation,
@@ -277,7 +277,7 @@ export const TimedExam = () => {
   }
 
   // Show "ready to start" UI when no active attempt exists
-  if (_.isEmpty(examInfo?.exam?.attempt) || _.isEmpty(examInfo?.active_attempt)) {
+  if (isEmpty(examInfo?.exam?.attempt) || isEmpty(examInfo?.active_attempt)) {
     return (
       <div className="sm:p-6">
         <div className="mb-8 rounded-lg border border-blue-200 bg-blue-50 p-6">

--- a/components/header/profile/tenant-select.tsx
+++ b/components/header/profile/tenant-select.tsx
@@ -1,7 +1,7 @@
 import { TenantSwitcher } from '@iblai/iblai-js/web-containers';
 import { getTenant, getTenants, handleTenantSwitch } from '@/utils/helpers';
 import { Tenant } from '@iblai/iblai-js/web-utils';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { selectRbacPermissions } from '@/features/rbac';
 import { useAppSelector } from '@/lib/hooks';
 import { config } from '@/lib/config';
@@ -11,7 +11,7 @@ export function TenantSelect() {
   const tenants = getTenants() as Tenant[];
   const rbacPermissions = useAppSelector(selectRbacPermissions);
 
-  if (_.isEmpty(tenants) || !tenantKey) {
+  if (isEmpty(tenants) || !tenantKey) {
     return <></>;
   }
 

--- a/components/profile-info-cards.tsx
+++ b/components/profile-info-cards.tsx
@@ -12,7 +12,7 @@ import duration from 'dayjs/plugin/duration';
 dayjs.extend(duration);
 import { useState } from 'react';
 import { UserActivityInfo } from '@/types/perlearner';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { SkeletonMultiplier } from './skeleton-multiplier';
 import Link from 'next/link';
 
@@ -32,7 +32,7 @@ export function ProfileInfoCards() {
         org: getTenant(),
         username: getUserName(),
       });
-      if (activityError || _.isEmpty(response.data)) {
+      if (activityError || isEmpty(response.data)) {
         throw new Error('Error fetching per learner activity');
       }
       const sortedData = [...response.data.data].sort((a, b) => b.time_invested - a.time_invested);

--- a/components/profile/__tests__/media-box.test.tsx
+++ b/components/profile/__tests__/media-box.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
+import isEmpty from 'lodash/isEmpty';
 
 vi.mock('@/utils/helpers', () => ({
   getTenant: vi.fn(() => 'test-tenant'),
@@ -94,12 +95,10 @@ vi.mock('@tanstack/react-form', () => ({
   }),
 }));
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn(
-      (val) => !val || (typeof val === 'object' ? Object.keys(val).length === 0 : false),
-    ),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn(
+    (val) => !val || (typeof val === 'object' ? Object.keys(val).length === 0 : false),
+  ),
 }));
 
 import { MediaBox } from '../media-box';
@@ -297,8 +296,7 @@ describe('MediaBox', () => {
   });
 
   it('handles empty file input', async () => {
-    const _ = await import('lodash');
-    vi.mocked(_.default.isEmpty).mockReturnValue(true);
+    vi.mocked(isEmpty).mockReturnValue(true);
     render(<MediaBox />);
     const fileInput = document.getElementById('file-input') as HTMLInputElement;
     if (fileInput) {
@@ -312,8 +310,7 @@ describe('MediaBox', () => {
   });
 
   it('shows selected file name after selection', async () => {
-    const lodash = await import('lodash');
-    vi.mocked(lodash.default.isEmpty).mockReturnValue(false);
+    vi.mocked(isEmpty).mockReturnValue(false);
 
     render(<MediaBox />);
     const fileInput = document.getElementById('file-input') as HTMLInputElement;

--- a/components/profile/__tests__/profile-skills-content.test.tsx
+++ b/components/profile/__tests__/profile-skills-content.test.tsx
@@ -11,12 +11,10 @@ vi.mock('lucide-react', () => ({
 }));
 
 // Mock lodash
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn(
-      (val: any) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
-    ),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn(
+    (val: any) => !val || (Array.isArray(val) ? val.length === 0 : Object.keys(val).length === 0),
+  ),
 }));
 
 // Mock useProfileSkills

--- a/components/profile/__tests__/skills-box.test.tsx
+++ b/components/profile/__tests__/skills-box.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 const mockUseProfileSkills = vi.fn();
 vi.mock('@/hooks/profile/use-profile-skills', () => ({
@@ -42,10 +42,8 @@ const isEmptyImpl = (val: any): boolean => {
   return false;
 };
 
-vi.mock('lodash', () => ({
-  default: {
-    isEmpty: vi.fn((val: any) => isEmptyImpl(val)),
-  },
+vi.mock('lodash/isEmpty', () => ({
+  default: vi.fn((val: any) => isEmptyImpl(val)),
 }));
 
 import { SkillsBox } from '../skills-box';
@@ -66,7 +64,7 @@ describe('SkillsBox', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset isEmpty to smart implementation
-    vi.mocked(_.isEmpty).mockImplementation((val: any) => isEmptyImpl(val));
+    vi.mocked(isEmpty).mockImplementation((val: any) => isEmptyImpl(val));
   });
 
   it('renders without crashing', () => {

--- a/components/profile/media-box.tsx
+++ b/components/profile/media-box.tsx
@@ -22,7 +22,7 @@ import Link from 'next/link';
 import { useForm } from '@tanstack/react-form';
 import { toast } from 'sonner';
 import { useCreateUserResumeMutation } from '@/services/career';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { Checkbox } from '../ui/checkbox';
 import { Label } from '../ui/label';
 import { useTenantMetadata } from '@iblai/iblai-js/web-utils';
@@ -166,7 +166,7 @@ export const MediaBox = () => {
   const [uploadedFileIsPDF, setUploadedFileIsPDF] = useState<boolean>(false);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (_.isEmpty(event.target.files)) {
+    if (isEmpty(event.target.files)) {
       return;
     }
     const file = event.target.files?.[0];

--- a/components/profile/profile-skills-content.tsx
+++ b/components/profile/profile-skills-content.tsx
@@ -8,7 +8,7 @@ import { useProfileSkills } from '@/hooks/profile/use-profile-skills';
 import { SkillBox } from '@/components/skill-box';
 import { SkeletonSkillBox } from '@/components/skeleton-skill-box';
 import { DefaultEmptyBox } from '@/components/default-empty-box';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { SkeletonMultiplier } from '@/components/skeleton-multiplier';
 import { UserSkill } from '@/types/skills';
 
@@ -92,12 +92,12 @@ export function ProfileSkillsContent() {
           {!earnedSkillsLoading && earnedSkillsError && (
             <DefaultEmptyBox className="w-full" message="You don't have any earned skills yet." />
           )}
-          {!earnedSkillsLoading && earnedSkillsSuccess && _.isEmpty(earnedSkills) && (
+          {!earnedSkillsLoading && earnedSkillsSuccess && isEmpty(earnedSkills) && (
             <DefaultEmptyBox className="w-full" message="You don't have any earned skills yet." />
           )}
           {!earnedSkillsLoading &&
             earnedSkillsSuccess &&
-            !_.isEmpty(earnedSkills?.resources) &&
+            !isEmpty(earnedSkills?.resources) &&
             earnedSkills?.resources.map((skill: any, index: number) => (
               <SkillBox
                 key={index}
@@ -155,7 +155,7 @@ export function ProfileSkillsContent() {
                 not here — so mobile doesn't show a duplicate box. */}
             {!selfReportedSkillsLoading &&
               selfReportedSkillsSuccess &&
-              !_.isEmpty(selfReportedSkills?.skills) &&
+              !isEmpty(selfReportedSkills?.skills) &&
               selfReportedSkills?.skills.map((skill: any, index: number) => (
                 <SkillBox
                   key={index}
@@ -187,7 +187,7 @@ export function ProfileSkillsContent() {
         )}
         {!selfReportedSkillsLoading &&
           selfReportedSkillsSuccess &&
-          _.isEmpty(selfReportedSkills?.skills) && (
+          isEmpty(selfReportedSkills?.skills) && (
             <DefaultEmptyBox
               className="w-full"
               message="You don't have any self-reported skills yet."
@@ -200,7 +200,7 @@ export function ProfileSkillsContent() {
 
           {!selfReportedSkillsLoading &&
             selfReportedSkillsSuccess &&
-            !_.isEmpty(selfReportedSkills?.skills) &&
+            !isEmpty(selfReportedSkills?.skills) &&
             selfReportedSkills?.skills.map((skill: any, index: number) => (
               <SkillBox
                 key={index}
@@ -262,7 +262,7 @@ export function ProfileSkillsContent() {
           {!desiredSkillsLoading && desiredSkillsError && (
             <DefaultEmptyBox className="w-full" message="You don't have any desired skills yet." />
           )}
-          {!desiredSkillsLoading && desiredSkillsSuccess && _.isEmpty(desiredSkills?.skills) && (
+          {!desiredSkillsLoading && desiredSkillsSuccess && isEmpty(desiredSkills?.skills) && (
             <DefaultEmptyBox className="w-full" message="You don't have any desired skills yet." />
           )}
 
@@ -276,7 +276,7 @@ export function ProfileSkillsContent() {
                   not here — so mobile doesn't show a duplicate box. */}
               {!desiredSkillsLoading &&
                 desiredSkillsSuccess &&
-                !_.isEmpty(desiredSkills?.skills) &&
+                !isEmpty(desiredSkills?.skills) &&
                 desiredSkills?.skills.map((skill: any, index: number) => (
                   <SkillBox
                     key={index}
@@ -296,7 +296,7 @@ export function ProfileSkillsContent() {
             )}
             {!desiredSkillsLoading &&
               desiredSkillsSuccess &&
-              !_.isEmpty(desiredSkills?.skills) &&
+              !isEmpty(desiredSkills?.skills) &&
               desiredSkills?.skills.map((skill: any, index: number) => (
                 <SkillBox
                   key={index}

--- a/components/profile/skills-box.tsx
+++ b/components/profile/skills-box.tsx
@@ -5,7 +5,7 @@ import { SkeletonMultiplier } from '../skeleton-multiplier';
 import { SkeletonSkillBox } from '../skeleton-skill-box';
 import { DefaultEmptyBox } from '../default-empty-box';
 import { SkillBox } from '../skill-box';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 export const SkillsBox = () => {
   const {
@@ -26,14 +26,14 @@ export const SkillsBox = () => {
       {/* Earned Skills Section */}
       <div className="mb-6">
         <h3 className="mb-4 text-base font-medium text-gray-700">Earned</h3>
-        {!earnedSkillsLoading && (earnedSkillsError || _.isEmpty(earnedSkills?.resources)) && (
+        {!earnedSkillsLoading && (earnedSkillsError || isEmpty(earnedSkills?.resources)) && (
           <DefaultEmptyBox className="w-full" message="You don't have any earned skills yet." />
         )}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {earnedSkillsLoading && <SkeletonMultiplier Skeleton={SkeletonSkillBox} multiplier={6} />}
           {!earnedSkillsLoading &&
             !earnedSkillsError &&
-            !_.isEmpty(earnedSkills?.resources) &&
+            !isEmpty(earnedSkills?.resources) &&
             earnedSkills?.resources.map((skill: any, index: number) => (
               <SkillBox
                 key={index}
@@ -59,7 +59,7 @@ export const SkillsBox = () => {
         )}
         {!selfReportedSkillsLoading &&
           !selfReportedSkillsError &&
-          _.isEmpty(selfReportedSkills?.skills) && (
+          isEmpty(selfReportedSkills?.skills) && (
             <DefaultEmptyBox
               className="w-full"
               message="You don't have any self-reported skills yet."
@@ -71,7 +71,7 @@ export const SkillsBox = () => {
           )}
           {!selfReportedSkillsLoading &&
             !selfReportedSkillsError &&
-            !_.isEmpty(selfReportedSkills?.skills) &&
+            !isEmpty(selfReportedSkills?.skills) &&
             selfReportedSkills?.skills.map((skill: any, index: number) => (
               <SkillBox
                 key={index}
@@ -91,7 +91,7 @@ export const SkillsBox = () => {
         {!desiredSkillsLoading && desiredSkillsError && (
           <DefaultEmptyBox className="w-full" message="You don't have any desired skills yet." />
         )}
-        {!desiredSkillsLoading && !desiredSkillsError && _.isEmpty(desiredSkills?.skills) && (
+        {!desiredSkillsLoading && !desiredSkillsError && isEmpty(desiredSkills?.skills) && (
           <DefaultEmptyBox className="w-full" message="You don't have any desired skills yet." />
         )}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -100,7 +100,7 @@ export const SkillsBox = () => {
           )}
           {!desiredSkillsLoading &&
             !desiredSkillsError &&
-            !_.isEmpty(desiredSkills?.skills) &&
+            !isEmpty(desiredSkills?.skills) &&
             desiredSkills?.skills.map((skill: any, index: number) => (
               <SkillBox
                 key={index}

--- a/hooks/courses/course-detail-context.tsx
+++ b/hooks/courses/course-detail-context.tsx
@@ -2,7 +2,7 @@
 
 import type React from 'react';
 import { createContext, useContext, useEffect } from 'react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useCourseDetail } from '@/hooks/courses/use-course-detail';
 
 type CourseDetailContextValue = ReturnType<typeof useCourseDetail>;
@@ -28,7 +28,7 @@ export function CourseDetailProvider({
   const { handleFetchCourseInfo } = value;
 
   useEffect(() => {
-    if (_.isEmpty(courseId)) return;
+    if (isEmpty(courseId)) return;
     handleFetchCourseInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseId]);

--- a/hooks/courses/use-course-detail.ts
+++ b/hooks/courses/use-course-detail.ts
@@ -7,7 +7,7 @@ import {
   CourseOutlineResponse,
   CourseProgress,
 } from '@/types/courses';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { getTenant, getUserName, handleNotLoggedInAction, inIframe } from '@/utils/helpers';
 import { config } from '@/lib/config';
 import dayjs from 'dayjs';
@@ -232,7 +232,7 @@ export const useCourseDetail = (rawCourseId: string) => {
     }
 
     const courseEligibility = await handleFetchCourseEligibility(courseId);
-    if (!_.isEmpty(courseEligibility)) {
+    if (!isEmpty(courseEligibility)) {
       const enrollmentStarted = dayjs(course?.enrollment_start).diff(dayjs(), 'seconds') > 0;
       const isEnrolled = courseEligibility.is_enrolled;
       const canEnroll = courseEligibility.can_enroll;
@@ -321,7 +321,7 @@ export const useCourseDetail = (rawCourseId: string) => {
   // machine) entirely inside the hook so consumers don't have to remember to
   // wire it up.
   useEffect(() => {
-    if (_.isEmpty(course)) return;
+    if (isEmpty(course)) return;
     handleFetchCourseEligibilityInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [course?.course_key]);
@@ -330,7 +330,7 @@ export const useCourseDetail = (rawCourseId: string) => {
     setCourseInfoLoadingState('loading');
     try {
       const courseMetaData = await handleFetchCourseMetaData(courseId);
-      if (!_.isEmpty(courseMetaData)) {
+      if (!isEmpty(courseMetaData)) {
         setCourse(courseMetaData as CourseEdxData);
         setCourseInfoLoadingState('successful');
       } else {
@@ -350,7 +350,7 @@ export const useCourseDetail = (rawCourseId: string) => {
     const courseCompletionOutlines = (await handleFetchCourseCompletionOutlines(courseId)) as
       | CourseOutlineResponse
       | Record<string, any>;
-    if (!_.isEmpty(courseCompletionOutlines)) {
+    if (!isEmpty(courseCompletionOutlines)) {
       //const coursesSyllabus = courseCompletionOutlines.children as CourseOutlineChildNode[];
       setCourseOutline(courseCompletionOutlines as CourseOutlineChildNode);
       if (setLoadingState) {
@@ -389,7 +389,7 @@ export const useCourseDetail = (rawCourseId: string) => {
         throw new Error('Error fetching course progress');
       }
       setCourseProgress(courseProgress.data || null);
-      if (!_.isEmpty(courseProgress.data)) {
+      if (!isEmpty(courseProgress.data)) {
         setCourseGradingPolicyActive(
           Array.isArray(courseProgress.data?.grading_policy?.assignment_policies) &&
             courseProgress.data?.grading_policy?.assignment_policies.length > 0,

--- a/hooks/discover/use-discover.ts
+++ b/hooks/discover/use-discover.ts
@@ -3,7 +3,8 @@ import { usePersonnalizedCatalogQuery } from '../search/use-personnalized-catalo
 import { useRecommendedCourses } from '../courses/use-recommended-courses';
 import { useEffect, useMemo, useState } from 'react';
 import { Course, CourseFacet } from '@/types/courses';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import { useDebounce } from 'use-debounce';
 import { config } from '@/lib/config';
 import { DiscoverContent } from '@/types/discover';
@@ -136,48 +137,48 @@ export const useDiscover = ({
       limit,
       offset: (page - 1) * limit,
       ...(!metadata?.skills_include_community_courses && { tenant: tenant }),
-      ...(!_.isEmpty(selectedFacets?.q) && {
+      ...(!isEmpty(selectedFacets?.q) && {
         query: selectedFacets?.q[0],
       }),
-      ...(!_.isEmpty(selectedFacets?.content) && {
+      ...(!isEmpty(selectedFacets?.content) && {
         content: selectedFacets?.content,
       }),
-      ...(!_.isEmpty(selectedFacets?.language) && {
+      ...(!isEmpty(selectedFacets?.language) && {
         language: selectedFacets?.language,
       }),
-      ...(!_.isEmpty(selectedFacets?.level) && {
+      ...(!isEmpty(selectedFacets?.level) && {
         level: selectedFacets?.level,
       }),
-      ...(!_.isEmpty(selectedFacets?.provider) && {
+      ...(!isEmpty(selectedFacets?.provider) && {
         provider: selectedFacets?.provider,
       }),
-      ...(!_.isEmpty(selectedFacets?.topics) && {
+      ...(!isEmpty(selectedFacets?.topics) && {
         topics: selectedFacets?.topics,
       }),
-      ...(!_.isEmpty(selectedFacets?.tags) && {
+      ...(!isEmpty(selectedFacets?.tags) && {
         tags: selectedFacets?.tags,
       }),
-      ...(!_.isEmpty(selectedFacets?.promotion) && {
+      ...(!isEmpty(selectedFacets?.promotion) && {
         promotion: selectedFacets?.promotion,
       }),
-      ...(!_.isEmpty(selectedFacets?.['course duration']) && {
+      ...(!isEmpty(selectedFacets?.['course duration']) && {
         duration: selectedFacets?.['course duration'],
       }),
-      ...(!_.isEmpty(selectedFacets?.certificate) && {
+      ...(!isEmpty(selectedFacets?.certificate) && {
         certificate: selectedFacets?.certificate,
       }),
       // The "Format" facet (self-paced / instructor-led) maps to the
       // endpoint's `self_paced` parameter.
-      ...(!_.isEmpty(selectedFacets?.format) && {
+      ...(!isEmpty(selectedFacets?.format) && {
         selfPaced: selectedFacets?.format,
       }),
-      ...(!_.isEmpty(selectedFacets?.price) && {
+      ...(!isEmpty(selectedFacets?.price) && {
         price: selectedFacets?.price.at(-1),
       }),
-      ...(!_.isEmpty(selectedFacets?.subject) && {
+      ...(!isEmpty(selectedFacets?.subject) && {
         subject: selectedFacets?.subject,
       }),
-      ...(!_.isEmpty(selectedFacets?.skills) && {
+      ...(!isEmpty(selectedFacets?.skills) && {
         skills: selectedFacets?.skills,
       }),
     }),
@@ -188,7 +189,7 @@ export const useDiscover = ({
   // Soften rapid facet toggling like the old imperative debounce did; the
   // first value is emitted immediately, so the initial load is not delayed.
   const [debouncedContentSearchParams] = useDebounce(contentSearchParams, 500, {
-    equalityFn: _.isEqual,
+    equalityFn: isEqual,
   });
 
   const facetSearchParams = useMemo(
@@ -236,7 +237,7 @@ export const useDiscover = ({
     try {
       let formattedFacets: CourseFacet[] = [];
       Object.keys(allFacets).forEach((key) => {
-        if (!_.isEmpty(allFacets[key]?.terms)) {
+        if (!isEmpty(allFacets[key]?.terms)) {
           const terms = Object.keys(allFacets[key]?.terms || {})
             .filter((innerTerm) => allFacets[key]?.terms[innerTerm] > 0)
             .map((innerTerm) => {
@@ -406,7 +407,7 @@ export const useDiscover = ({
   const displayCards = useMemo<DiscoverContentCardProps[]>(() => {
     if (enrolledOnly || recommendedOnly) {
       const selectedTypes = (
-        !_.isEmpty(selectedFacets?.content)
+        !isEmpty(selectedFacets?.content)
           ? selectedFacets.content
           : ['courses', 'programs', 'pathways']
       ).filter((type): type is EnrolledContentType => type in enrolledCards);

--- a/hooks/profile/use-all-time-stats.ts
+++ b/hooks/profile/use-all-time-stats.ts
@@ -6,7 +6,7 @@ import {
   // @ts-ignore
   useLazyGetUserDesiredSkillsQuery,
 } from '@iblai/iblai-js/data-layer';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useLazyGetUserCredentialsQuery } from '@/services/credentials';
 import { useLazyGetUserEnrolledCoursesQuery } from '@/services/courses';
 
@@ -69,7 +69,7 @@ export const useAllTimeStats = () => {
         },
         true,
       );
-      if (isErrorGetUserCredentials || _.isEmpty(response?.data)) {
+      if (isErrorGetUserCredentials || isEmpty(response?.data)) {
         throw new Error();
       }
       setCredentials(response?.data?.data?.length || 0);
@@ -86,7 +86,7 @@ export const useAllTimeStats = () => {
         },
         true,
       );
-      if (isErrorGetUserEnrolledCourses || _.isEmpty(response.data)) {
+      if (isErrorGetUserEnrolledCourses || isEmpty(response.data)) {
         throw new Error();
       }
       setCourses(response?.data?.count || 0);

--- a/hooks/profile/use-profile-activity-stats.ts
+++ b/hooks/profile/use-profile-activity-stats.ts
@@ -11,7 +11,8 @@ import {
   // @ts-ignore
   useLazyGetPerLearnerInfoQuery,
 } from '@iblai/iblai-js/data-layer';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import sumBy from 'lodash/sumBy';
 import { useLazyGetUserCredentialsQuery } from '@/services/credentials';
 import { useLazyGetUserPerLearnerInfoQuery } from '@/services/perlearner';
 import { useLazyGetUserEnrolledCoursesQuery } from '@/services/courses';
@@ -79,12 +80,12 @@ export const useProfileActivityStats = () => {
         ],
         true,
       );
-      if (isErrorGetUserSkillsPoints || _.isEmpty(response?.data?.skill_points)) {
+      if (isErrorGetUserSkillsPoints || isEmpty(response?.data?.skill_points)) {
         throw new Error();
       }
       updateSingleStat({
         value:
-          _.sumBy(
+          sumBy(
             Object.values(response.data?.skill_points || {}),
             (skill: any) => skill.total_points,
           ) || 0,
@@ -155,7 +156,7 @@ export const useProfileActivityStats = () => {
         },
         true,
       );
-      if (isErrorGetUserCredentials || _.isEmpty(response?.data)) {
+      if (isErrorGetUserCredentials || isEmpty(response?.data)) {
         throw new Error();
       }
       updateSingleStat({
@@ -182,7 +183,7 @@ export const useProfileActivityStats = () => {
         },
         true,
       );
-      if (isErrorGetUserEnrolledCourses || _.isEmpty(response.data)) {
+      if (isErrorGetUserEnrolledCourses || isEmpty(response.data)) {
         throw new Error();
       }
       updateSingleStat({
@@ -210,7 +211,7 @@ export const useProfileActivityStats = () => {
         },
         true,
       );
-      if (isEnrolledProgramsError || _.isEmpty(response.data)) {
+      if (isEnrolledProgramsError || isEmpty(response.data)) {
         throw new Error();
       }
       updateSingleStat({
@@ -247,7 +248,7 @@ export const useProfileActivityStats = () => {
         },
         true,
       );
-      if (isCatalogPathwaysError || _.isEmpty(response.data)) {
+      if (isCatalogPathwaysError || isEmpty(response.data)) {
         throw new Error();
       }
       const uniquePathways = filterUniquePathways(response.data);
@@ -281,7 +282,7 @@ export const useProfileActivityStats = () => {
         ],
         true,
       );
-      if (isErrorgetPerLearnerInfo || _.isEmpty(response.data)) {
+      if (isErrorgetPerLearnerInfo || isEmpty(response.data)) {
         throw new Error();
       }
       updateSingleStat({
@@ -321,7 +322,7 @@ export const useProfileActivityStats = () => {
         },
         true,
       );
-      if (isErrorGetUserPerLearnerInfo || _.isEmpty(response.data)) {
+      if (isErrorGetUserPerLearnerInfo || isEmpty(response.data)) {
         throw new Error();
       }
       const totalTimeSpentSeconds = response?.data?.data?.total_time_spent;

--- a/hooks/profile/use-profile-timespent.ts
+++ b/hooks/profile/use-profile-timespent.ts
@@ -6,7 +6,7 @@ import { useLazyGetOverTimeActivityQuery } from '@iblai/iblai-js/data-layer';
 import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 dayjs.extend(duration);
 
 export const useProfileTimeSpent = () => {
@@ -31,7 +31,7 @@ export const useProfileTimeSpent = () => {
         ],
         true,
       );
-      if (isErrorGetOverTimeActivity || _.isEmpty(response?.data?.data)) {
+      if (isErrorGetOverTimeActivity || isEmpty(response?.data?.data)) {
         throw new Error();
       }
       setTimeSpent(

--- a/hooks/use-default-mentor.ts
+++ b/hooks/use-default-mentor.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 // @ts-ignore
 import { useLazyGetMentorsQuery } from '@iblai/iblai-js/data-layer';
 import { useTenantMetadata } from '@iblai/iblai-js/web-utils';
@@ -88,7 +88,7 @@ export function useDefaultMentor({
           limit: 10,
         }).unwrap();
 
-        let resolved = _.isEmpty(recent?.results) ? null : resolveMentor(recent.results);
+        let resolved = isEmpty(recent?.results) ? null : resolveMentor(recent.results);
 
         // Step 4 - fall back to featured mentors when none are recently accessed
         if (!resolved) {
@@ -98,7 +98,7 @@ export function useDefaultMentor({
             featured: true,
             limit: 10,
           }).unwrap();
-          resolved = _.isEmpty(featured?.results) ? null : resolveMentor(featured.results);
+          resolved = isEmpty(featured?.results) ? null : resolveMentor(featured.results);
         }
 
         if (!resolved) {


### PR DESCRIPTION
## Why

skillsai imported the **entire** lodash library — `import _ from 'lodash'` — across **23 files**, but used only three functions: `isEmpty` (everywhere), plus `isEqual` and `sumBy` in two hooks. Because it's a **default namespace import**, `optimizePackageImports` can't tree-shake it, so all of lodash (~25 KB gzip) shipped in the main bundle.

This came out of a "port the os load-time optimizations to skillsai" pass. Most of those don't apply — skillsai has no Sentry, no syntax-highlighter/LiveKit (those live in the embedded mentor), already has `optimizePackageImports`, and already lazy-loads its heavy components (react-pdf/ResumeBox, etc.). The full-lodash import was the one real gap.

## Change

Every call site now uses a per-method deep import so only the used functions are bundled:

```diff
- import _ from 'lodash';
- if (_.isEmpty(x)) …
+ import isEmpty from 'lodash/isEmpty';
+ if (isEmpty(x)) …
```

(`isEqual` in `use-discover.ts`, `sumBy` in `use-profile-activity-stats.ts` get the same treatment.) Behaviour is **identical** — same lodash functions, just imported directly.

## Tests

The 12 test files that mocked the `lodash` barrel now mock `lodash/isEmpty`. Verified:
- The 12 lodash-mock suites — **391 tests pass**.
- The two affected hook suites (`use-discover`, `use-profile-activity-stats`) — **59 tests pass**.
- `pnpm typecheck` introduces **no new errors** (the one remaining error, `app-sidebar/index.tsx:474` `rbackPermissions`, is pre-existing on `main` and out of scope).