### PR TITLE
fix(pr-gate): derive the verdict from the E2E job, not the workflow conclusion

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   statuses: write
   pull-requests: read
+  actions: read          # update-gate reads the E2E run's jobs to derive the verdict
 
 jobs:
   # ── On pull_request: set initial gate status ──
@@ -65,6 +66,21 @@ jobs:
             }
 
   # ── On workflow_run: update gate after E2E tests finish ──
+  #
+  # The verdict comes from the E2E JOB, never from the workflow-level conclusion. A workflow whose
+  # jobs were all skipped concludes `success` — that is normal GitHub behaviour and it is NOT a
+  # pass. Reading `workflow_run.conclusion` directly produced two live faults:
+  #
+  #   FALSE GREEN (the dangerous one). pr-e2e-tests.yml triggers on every `labeled` event, so
+  #   applying ANY label to a PR that lacks `run-tests` starts a run whose `gate` is skipped,
+  #   everything downstream is skipped, the workflow reports `success`, and this step published
+  #   "PR E2E Tests passed" — overwriting the correct "Add the run-tests label" block. In lms,
+  #   11 of 11 sampled sub-30s "successful" runs did exactly that: a required check went green
+  #   having tested nothing, leaving the PR mergeable.
+  #
+  #   FALSE RED. concurrency (`pr-e2e-<PR#>`, cancel-in-progress) supersedes the older run when
+  #   two events land together. Two labels applied in the same second put lms#232 into
+  #   "PR E2E Tests cancelled" while the surviving run was still building.
   update-gate:
     if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
@@ -75,17 +91,65 @@ jobs:
           script: |
             const run = context.payload.workflow_run;
             const sha = run.head_sha;
-            const conclusion = run.conclusion; // success, failure, cancelled, etc.
+            const { owner, repo } = context.repo;
 
-            const passed = conclusion === 'success';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha,
-              state: passed ? 'success' : 'failure',
-              context: 'PR Validation',
-              description: passed
-                ? 'PR E2E Tests passed'
-                : `PR E2E Tests ${conclusion}`,
+            const setStatus = (state, description) =>
+              github.rest.repos.createCommitStatus({
+                owner, repo, sha, state, context: 'PR Validation', description,
+              });
+
+            // Release branches are auto-passed by the pull_request job above; don't undo that.
+            if ((run.head_branch || '').startsWith('release/')) {
+              core.info('release branch — leaving the auto-pass in place');
+              return;
+            }
+
+            // A cancelled run is not a verdict — concurrency superseded it, and the run that
+            // superseded it will post the real result. Writing `failure` here shows a healthy PR
+            // as broken and, if this event arrives after the survivor's success, overwrites a
+            // green check with nothing left to re-run it.
+            if (run.conclusion === 'cancelled') {
+              core.info('run cancelled (superseded by concurrency) — leaving the status alone');
+              return;
+            }
+
+            // Never let an older run overwrite a newer one's verdict. Run ids increase
+            // monotonically, so a higher id for this same sha is strictly more recent.
+            const { data: siblings } = await github.rest.actions.listWorkflowRuns({
+              owner, repo, workflow_id: run.workflow_id, head_sha: sha, per_page: 100,
             });
-            core.info(`E2E tests ${conclusion} — set PR Validation to ${passed ? 'success' : 'failure'}`);
+            if (siblings.workflow_runs.some(r => r.id > run.id)) {
+              core.info(`newer run exists for ${sha.slice(0, 8)} — deferring to it`);
+              return;
+            }
+
+            // The verdict: what did the jobs actually do?
+            const { data: jobList } = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 100,
+            });
+            const gate = jobList.jobs.find(j => j.name === 'gate');
+            const e2e  = jobList.jobs.find(j => j.name.startsWith('E2E'));
+
+            // Gate skipped => no run-tests label (or a fork). This run tested nothing, so restore
+            // the blocking status instead of passing. An unknown state must never yield a green
+            // required check — that is the entire purpose of this gate.
+            if (!gate || gate.conclusion === 'skipped') {
+              await setStatus('failure', 'Add the run-tests label to trigger validation');
+              core.info('gate skipped — this run tested nothing; restored the blocking status');
+              return;
+            }
+
+            // Gate ran but E2E did not => an earlier job (build) failed. Report that honestly
+            // rather than blaming a missing label.
+            if (!e2e || e2e.conclusion === 'skipped') {
+              await setStatus('failure', 'PR E2E Tests did not run — an earlier job failed');
+              core.info('E2E skipped despite gate passing — upstream job failure');
+              return;
+            }
+
+            const passed = e2e.conclusion === 'success';
+            await setStatus(
+              passed ? 'success' : 'failure',
+              passed ? 'PR E2E Tests passed' : `PR E2E Tests ${e2e.conclusion}`,
+            );
+            core.info(`E2E job ${e2e.conclusion} — PR Validation ${passed ? 'success' : 'failure'}`);


### PR DESCRIPTION
`update-gate` mapped `workflow_run.conclusion` straight onto the required **`PR Validation`** check. That conclusion says nothing about whether tests actually ran, and it has been producing two live faults.

## 🔴 False green — the dangerous one

`pr-e2e-tests.yml` triggers on **every** `labeled` event. Apply *any* label to a PR without `run-tests` and:

```
skipped   gate                      <- no run-tests label
skipped   build-app-image
skipped   E2E (central pipeline)
success   summary
          => workflow conclusion: success       (normal GitHub behaviour for an all-skipped run)
```

`update-gate` then published **"PR E2E Tests passed"**. Real example — `lms` run `33528234468` on `feat/edx-token-expiry-check`:

```
15:50:47  failure   Add the run-tests label to trigger validation   <- correct
15:51:00  success   PR E2E Tests passed                             <- FALSE, 13s later
```

**11 of 11** sampled sub-30s "successful" runs in `lms` did exactly this. The required check went green having tested nothing, overwriting the correct block and leaving the PR mergeable.

## 🟡 False red

`concurrency: pr-e2e-<PR#>` with `cancel-in-progress` supersedes the older run whenever two events land together. On **lms#232**, two labels were applied in the same second:

```
17:30:57  PR opened
17:30:58  labeled: priority      -> run A
17:30:58  labeled: run-tests     -> run B, cancels A
17:31:18  PR Validation = failure "PR E2E Tests cancelled"   <- from the killed duplicate
```

The healthy run was still building. And because GitHub does not order `workflow_run` delivery, a cancellation arriving *after* the survivor's success **permanently overwrites a green check**, with nothing left to re-run it.

## The fix

The verdict now comes from the jobs, not the workflow:

| condition | behaviour |
|---|---|
| release branch | leave the `pull_request` job's auto-pass alone |
| `conclusion == cancelled` | not a verdict — leave the existing status alone |
| a newer run exists for this sha | defer to it (run ids are monotonic) |
| `gate` skipped | restore "Add the run-tests label" — **never pass** |
| `gate` ran, `E2E` skipped | "PR E2E Tests did not run — an earlier job failed" |
| otherwise | map the **E2E job's** own conclusion |

The governing principle: an unknown state must never yield a green required check.

Adds `actions: read` — required to list the run's jobs.

## Verification

The new decision logic replayed against real historical runs via the live API:

| run | was | now |
|---|---|---|
| `33528234468` gate skipped | ✅ "PR E2E Tests passed" | ❌ "Add the run-tests label" |
| `33559505973` dependabot | ✅ "PR E2E Tests passed" | ❌ "Add the run-tests label" |
| `33661558781` **#232**, cancelled | ❌ "PR E2E Tests cancelled" | skip — leave status alone |
| `33558220926` cancelled | ❌ failure | skip |
| `33558221504` genuine full run | ✅ passed | ✅ passed |

Also: YAML parses, `actionlint` clean, and both `github-script` bodies pass `node --check` when wrapped as async functions the way `github-script` executes them.

`lms` and `os` had byte-identical `pr-gate.yml`, so this same change is going to both. `iblai-web-frontend` has no `pr-gate.yml` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
