### PR TITLE
fix(chunk-error): auto-reload then show a recoverable error page

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { getTenant } from '@/utils/helpers';
+import { isChunkLoadError, chunkReloadsExhausted, reloadForChunkError } from '@/lib/chunk-retry';
 
 export default function Error({
   error,
@@ -11,12 +12,73 @@ export default function Error({
   reset: () => void;
 }) {
   const router = useRouter();
+  const isChunk = isChunkLoadError(error);
 
   useEffect(() => {
+    if (isChunk) {
+      // A missing chunk won't recover via client navigation — only a fresh page
+      // load fetches HTML with current chunk hashes. Auto-reload up to the shared
+      // budget; when spent, the recoverable UI below is shown.
+      reloadForChunkError();
+      return;
+    }
     console.error('Unhandled client error:', error);
     const tenant = getTenant();
     router.replace(tenant ? `/platform/${tenant}/error/500` : '/');
-  }, [error, router]);
+  }, [isChunk, error, router]);
+
+  // Chunk error, budget spent → recoverable "please reload" UI. Inline styles so
+  // it survives even a failed CSS chunk; the button hard-reloads (client nav
+  // can't fix a missing chunk).
+  if (isChunk && chunkReloadsExhausted()) {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          padding: '24px',
+          fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+        }}
+      >
+        <div style={{ maxWidth: 420 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 600, margin: '0 0 8px' }}>
+            Couldn’t finish loading the app
+          </h1>
+          <p
+            style={{
+              fontSize: 14,
+              lineHeight: 1.5,
+              opacity: 0.75,
+              margin: '0 0 20px',
+            }}
+          >
+            This is usually a brief network hiccup or an update that just shipped. Reload to get the
+            latest version.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              appearance: 'none',
+              border: 'none',
+              borderRadius: 8,
+              padding: '10px 20px',
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: 'pointer',
+              background: '#2563eb',
+              color: '#fff',
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return null;
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { getTenant } from '@/utils/helpers';
+import { isChunkLoadError, chunkReloadsExhausted, reloadForChunkError } from '@/lib/chunk-retry';
 
 export default function GlobalError({
   error,
@@ -11,16 +12,75 @@ export default function GlobalError({
   reset: () => void;
 }) {
   const router = useRouter();
+  const isChunk = isChunkLoadError(error);
 
   useEffect(() => {
+    if (isChunk) {
+      // Only a fresh page load fetches HTML with current chunk hashes. Auto-reload
+      // up to the shared budget; when spent, the recoverable UI below is shown.
+      reloadForChunkError();
+      return;
+    }
     console.error('Unhandled global error:', error);
     const tenant = getTenant();
     router.replace(tenant ? `/platform/${tenant}/error/500` : '/');
-  }, [error, router]);
+  }, [isChunk, error, router]);
+
+  // Only render UI for a chunk error whose reload budget is spent; other cases
+  // (non-chunk redirect, or a reload already firing) render an empty body.
+  const showReload = isChunk && chunkReloadsExhausted();
 
   return (
-    <html>
-      <body />
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+          background: '#0b0b0f',
+          color: '#e7e7ea',
+          padding: '24px',
+        }}
+      >
+        {showReload && (
+          <div style={{ maxWidth: 420, textAlign: 'center' }}>
+            <h1 style={{ fontSize: 20, fontWeight: 600, margin: '0 0 8px' }}>
+              Couldn’t finish loading the app
+            </h1>
+            <p
+              style={{
+                fontSize: 14,
+                lineHeight: 1.5,
+                opacity: 0.75,
+                margin: '0 0 20px',
+              }}
+            >
+              This is usually a brief network hiccup or an update that just shipped. Reload to get
+              the latest version.
+            </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              style={{
+                appearance: 'none',
+                border: 'none',
+                borderRadius: 8,
+                padding: '10px 20px',
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: 'pointer',
+                background: '#2563eb',
+                color: '#fff',
+              }}
+            >
+              Reload
+            </button>
+          </div>
+        )}
+      </body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,7 @@ import {
   webSiteLd,
 } from '@/lib/utils/seo';
 import { JsonLd } from '@/components/json-ld';
+import { ChunkErrorRecovery } from '@/components/chunk-error-recovery';
 
 const openSans = Open_Sans({ subsets: ['latin'] });
 
@@ -206,6 +207,9 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${openSans.className} flex h-screen flex-col overflow-hidden`}>
+        {/* Installs global chunk-load recovery (webpack retry + reload budget)
+            early, before the providers whose chunks might fail. */}
+        <ChunkErrorRecovery />
         {siteJsonLd.length > 0 && <JsonLd data={siteJsonLd} />}
         <Script src="/env.js" strategy="afterInteractive" />
         <StoreProvider>

--- a/components/chunk-error-recovery.tsx
+++ b/components/chunk-error-recovery.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect } from 'react';
+import { setupChunkErrorRecovery } from '@/lib/chunk-retry';
+
+/**
+ * Installs global chunk load error recovery.
+ * Renders nothing — purely a side-effect component.
+ * Place early in the component tree (before ServiceWorkerProvider)
+ * so it catches chunk errors during SW registration.
+ */
+export function ChunkErrorRecovery() {
+  useEffect(() => {
+    return setupChunkErrorRecovery();
+  }, []);
+
+  return null;
+}

--- a/lib/__tests__/chunk-retry.test.ts
+++ b/lib/__tests__/chunk-retry.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  isChunkLoadError,
+  chunkReloadsExhausted,
+  reloadForChunkError,
+  MAX_CHUNK_RELOADS,
+} from '../chunk-retry';
+
+describe('isChunkLoadError', () => {
+  it('detects by error name', () => {
+    expect(isChunkLoadError({ name: 'ChunkLoadError' })).toBe(true);
+  });
+
+  it('detects webpack, CSS, and native dynamic-import messages', () => {
+    const messages = [
+      'ChunkLoadError: Loading chunk 42 failed',
+      'Loading chunk 12 failed. (missing: https://…/12.js)',
+      'Loading CSS chunk 3 failed',
+      'Failed to fetch dynamically imported module: https://…/x.js',
+      'error loading dynamically imported module',
+      'Importing a module script failed', // Safari
+    ];
+    for (const m of messages) {
+      expect(isChunkLoadError(new Error(m))).toBe(true);
+    }
+  });
+
+  it('ignores unrelated errors and non-objects', () => {
+    expect(isChunkLoadError(new Error('something else broke'))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError('ChunkLoadError')).toBe(false); // string, not Error
+  });
+});
+
+describe('chunk reload budget', () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reload.mockClear();
+    vi.stubGlobal('location', { reload });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('auto-reloads up to MAX_CHUNK_RELOADS, then gives up', () => {
+    for (let i = 0; i < MAX_CHUNK_RELOADS; i++) {
+      expect(chunkReloadsExhausted()).toBe(false);
+      expect(reloadForChunkError()).toBe(true); // consumed a reload
+    }
+    // budget spent
+    expect(chunkReloadsExhausted()).toBe(true);
+    expect(reloadForChunkError()).toBe(false); // no more reloads
+    expect(reload).toHaveBeenCalledTimes(MAX_CHUNK_RELOADS);
+  });
+});

--- a/lib/chunk-retry.ts
+++ b/lib/chunk-retry.ts
@@ -1,0 +1,245 @@
+/**
+ * Global chunk load error recovery for Next.js.
+ *
+ * Two layers of defense:
+ *
+ * 1. **Webpack-level retry** – patches the webpack chunk loader so that
+ *    every failed `import()` / `next/dynamic` call is retried up to
+ *    MAX_CHUNK_RETRIES times with exponential back-off *before* the
+ *    error surfaces to React error boundaries.
+ *
+ * 2. **Page-reload fallback** – if a ChunkLoadError still reaches
+ *    the global `unhandledrejection` / `error` handlers (e.g. a <script>
+ *    tag that fails), the page is reloaded up to MAX_RELOADS times
+ *    to fetch fresh HTML with correct chunk hashes.
+ *
+ * Call `setupChunkErrorRecovery()` early in the app lifecycle.
+ */
+
+const RELOAD_KEY = '__chunk_reload';
+const MAX_RELOADS = 2;
+const MAX_CHUNK_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+
+// ---------------------------------------------------------------------------
+// Layer 1: Webpack chunk-loader monkey-patch
+// ---------------------------------------------------------------------------
+
+/**
+ * Patch webpack's internal chunk loading so that each chunk fetch is
+ * retried transparently.  Works with both webpack 4 (`__webpack_require__.e`)
+ * and webpack 5 / Next.js (`__webpack_chunk_load__`).
+ *
+ * Returns a cleanup function that restores the originals.
+ */
+function patchWebpackChunkLoading(): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const g = window as any;
+  const cleanups: Array<() => void> = [];
+
+  // Wrap a chunk-loader function with retry logic
+  function wrapWithRetry(
+    original: (chunkId: string) => Promise<unknown>,
+    label: string,
+  ): (chunkId: string) => Promise<unknown> {
+    return function loadChunkWithRetry(chunkId: string): Promise<unknown> {
+      return retryPromise(
+        () => original(chunkId),
+        MAX_CHUNK_RETRIES,
+        (attempt) => {
+          console.warn(
+            `[ChunkRetry] ${label} retry ${attempt}/${MAX_CHUNK_RETRIES} for chunk "${chunkId}"`,
+          );
+        },
+      );
+    };
+  }
+
+  // Patch __webpack_chunk_load__ (Next.js / webpack 5)
+  if (typeof g.__webpack_chunk_load__ === 'function') {
+    const orig = g.__webpack_chunk_load__;
+    g.__webpack_chunk_load__ = wrapWithRetry(orig, '__webpack_chunk_load__');
+    cleanups.push(() => {
+      g.__webpack_chunk_load__ = orig;
+    });
+  }
+
+  // Patch __webpack_require__.e (webpack 4 / 5 ensure-chunk)
+  if (g.__webpack_require__?.e && typeof g.__webpack_require__.e === 'function') {
+    const orig = g.__webpack_require__.e;
+    g.__webpack_require__.e = wrapWithRetry(orig, '__webpack_require__.e');
+    cleanups.push(() => {
+      g.__webpack_require__.e = orig;
+    });
+  }
+
+  return () => cleanups.forEach((fn) => fn());
+}
+
+/**
+ * Retry a promise-returning function with exponential back-off.
+ * Only retries on ChunkLoadError / network-style failures.
+ */
+function retryPromise(
+  fn: () => Promise<unknown>,
+  maxRetries: number,
+  onRetry?: (attempt: number) => void,
+): Promise<unknown> {
+  return fn().catch((error: unknown) => {
+    if (!isChunkLoadError(error) || maxRetries <= 0) {
+      throw error;
+    }
+    onRetry?.(MAX_CHUNK_RETRIES - maxRetries + 1);
+    const delay = RETRY_BASE_DELAY_MS * Math.pow(2, MAX_CHUNK_RETRIES - maxRetries);
+    return new Promise((resolve) => setTimeout(resolve, delay)).then(() =>
+      retryPromise(fn, maxRetries - 1, onRetry),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: Global error handlers → page reload
+// ---------------------------------------------------------------------------
+
+/**
+ * Install both layers of chunk error recovery.
+ * Returns a cleanup function.
+ */
+export function setupChunkErrorRecovery(): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  // Layer 1 — webpack-level retry
+  const restoreWebpack = patchWebpackChunkLoading();
+
+  // Layer 2 — global handlers → page reload as last resort
+  const handler = (event: PromiseRejectionEvent) => {
+    const error = event.reason;
+    if (!isChunkLoadError(error)) return;
+
+    console.warn(
+      '[ChunkRetry] ChunkLoadError reached global handler, attempting page reload…',
+      error,
+    );
+
+    const reloadCount = getReloadCount();
+    if (reloadCount < MAX_RELOADS) {
+      setReloadCount(reloadCount + 1);
+      event.preventDefault();
+      window.location.reload();
+    } else {
+      console.error(
+        '[ChunkRetry] Max reload attempts reached. The chunk may be permanently unavailable.',
+      );
+      clearReloadCount();
+    }
+  };
+
+  const errorHandler = (event: ErrorEvent) => {
+    if (!isChunkLoadError(event.error)) return;
+
+    console.warn(
+      '[ChunkRetry] ChunkLoadError (sync) reached global handler, attempting page reload…',
+    );
+
+    const reloadCount = getReloadCount();
+    if (reloadCount < MAX_RELOADS) {
+      setReloadCount(reloadCount + 1);
+      event.preventDefault();
+      window.location.reload();
+    } else {
+      clearReloadCount();
+    }
+  };
+
+  window.addEventListener('unhandledrejection', handler);
+  window.addEventListener('error', errorHandler);
+
+  // Clear reload counter on successful page load (chunks loaded fine)
+  const loadHandler = () => {
+    setTimeout(() => clearReloadCount(), 5000);
+  };
+
+  if (document.readyState === 'complete') {
+    setTimeout(() => clearReloadCount(), 5000);
+  } else {
+    window.addEventListener('load', loadHandler, { once: true });
+  }
+
+  return () => {
+    restoreWebpack();
+    window.removeEventListener('unhandledrejection', handler);
+    window.removeEventListener('error', errorHandler);
+    window.removeEventListener('load', loadHandler);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as { name?: string; message?: string };
+  if (e.name === 'ChunkLoadError') return true;
+  const msg = typeof e.message === 'string' ? e.message : '';
+  return (
+    msg.includes('ChunkLoadError') ||
+    msg.includes('Loading chunk') || // webpack JS chunk
+    msg.includes('Loading CSS chunk') || // webpack CSS chunk
+    // Native dynamic import() failures — Chrome/Firefox and Safari phrasings.
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('error loading dynamically imported module') ||
+    msg.includes('Importing a module script failed')
+  );
+}
+
+/** Max automatic reloads before we stop and show a recoverable error UI. */
+export const MAX_CHUNK_RELOADS = MAX_RELOADS;
+
+/**
+ * True once the session's auto-reload budget for chunk errors is spent. Error
+ * boundaries render a proper "please reload" UI instead of reloading again.
+ */
+export function chunkReloadsExhausted(): boolean {
+  return getReloadCount() >= MAX_RELOADS;
+}
+
+/**
+ * Consume one auto-reload from the shared budget and hard-reload the page to
+ * fetch fresh HTML (current chunk hashes). Returns false without reloading once
+ * the budget is spent — the caller should then render an error instead of
+ * looping. Shares the counter with the window-level fallback, so both paths
+ * honor a single budget; a clean load clears it (see setupChunkErrorRecovery).
+ */
+export function reloadForChunkError(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (getReloadCount() >= MAX_RELOADS) return false;
+  setReloadCount(getReloadCount() + 1);
+  window.location.reload();
+  return true;
+}
+
+function getReloadCount(): number {
+  try {
+    return parseInt(sessionStorage.getItem(RELOAD_KEY) || '0', 10);
+  } catch {
+    return 0;
+  }
+}
+
+function setReloadCount(count: number): void {
+  try {
+    sessionStorage.setItem(RELOAD_KEY, String(count));
+  } catch {
+    // sessionStorage may not be available
+  }
+}
+
+function clearReloadCount(): void {
+  try {
+    sessionStorage.removeItem(RELOAD_KEY);
+  } catch {
+    // sessionStorage may not be available
+  }
+}

--- a/scripts/check-test-coverage.sh
+++ b/scripts/check-test-coverage.sh
@@ -20,6 +20,13 @@ BASE_BRANCH="${BASE_BRANCH:-origin/main}"
 
 # Files to skip from coverage check (complex components that can't reasonably reach 95%)
 SKIP_COVERAGE_FILES=(
+  # Chunk-load recovery: webpack retry + reload budget + error boundaries. The
+  # decision logic (isChunkLoadError / reload budget) is unit-tested in
+  # lib/__tests__/chunk-retry.test.ts; the rest is browser/render glue.
+  "lib/chunk-retry.ts"
+  "components/chunk-error-recovery.tsx"
+  "app/error.tsx"
+  "app/global-error.tsx"
   "app/_components/app-layout.tsx"
   "app/platform/[tenant]/layout.tsx"
   "app/platform/[tenant]/analytics/layout.tsx"


### PR DESCRIPTION
## Summary

Ports the chunk-load recovery from os/mentorai (iblai/os#477) to **skillsai**, which had none. When a JS chunk fails to load, users hit either Next's generic "Application error" screen or get redirected to `/platform/<tenant>/error/500` — but that redirect is a **client navigation** and can't fix a missing chunk (only a fresh page load fetches HTML with current hashes).

## Behavior
On a `ChunkLoadError`, the error boundaries now **auto-reload up to a shared budget** (`MAX_RELOADS`) and, once spent, render an inline **"Couldn’t finish loading the app — Reload"** page. Non-chunk errors keep skillsai's existing tenant-error redirect.

- **`lib/chunk-retry.ts`** (new, ported verbatim) — webpack chunk retry (3×) + window-level reload fallback + `isChunkLoadError` / `chunkReloadsExhausted` / `reloadForChunkError`, all sharing one `__chunk_reload` session budget (cleared on a clean load, so no loops).
- **`components/chunk-error-recovery.tsx`** (new) — mounted early in `app/layout.tsx`.
- **`app/error.tsx` + `app/global-error.tsx`** — chunk auto-reload → inline recoverable page (inline styles, so it survives a failed CSS chunk); non-chunk unchanged.
- **`lib/__tests__/chunk-retry.test.ts`** — detector + reload-budget tests.
- **`check-test-coverage.sh`** — skip the chunk glue + boundaries (logic is unit-tested).