### PR TITLE
fix(storage): write strings raw so current_tenant does not double-encode

### DIFF
--- a/utils/__tests__/localstorage.test.ts
+++ b/utils/__tests__/localstorage.test.ts
@@ -116,12 +116,28 @@ describe('LocalStorageService', () => {
     expect(result).toBeNull();
   });
 
-  it('setItem calls localStorage.setItem with JSON-stringified value', async () => {
+  it('setItem JSON-stringifies a non-string value', async () => {
     await service.setItem('user', { name: 'Alice' });
     expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
       'user',
       JSON.stringify({ name: 'Alice' }),
     );
+  });
+
+  it('setItem writes a string as-is, so it round-trips through getItem', async () => {
+    // Stringifying here would double-encode: the SDK's cookie sync parses the
+    // result to a string rather than an object, sees `key` as undefined, and
+    // refreshes the page on every poll.
+    const tenant = JSON.stringify({ key: 'demo' });
+    await service.setItem('current_tenant', tenant);
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      'current_tenant',
+      tenant,
+    );
+
+    mockLocalStorage.getItem.mockReturnValue(tenant);
+    const readBack = await service.getItem<string>('current_tenant');
+    expect(JSON.parse(readBack as string)).toEqual({ key: 'demo' });
   });
 
   it('removeItem calls localStorage.removeItem', async () => {

--- a/utils/localstorage.ts
+++ b/utils/localstorage.ts
@@ -24,7 +24,15 @@ export class LocalStorageService implements StorageService {
   }
 
   async setItem<T>(key: string, item: T): Promise<void> {
-    window.localStorage.setItem(key, JSON.stringify(item));
+    // `getItem` reads raw, so a string must be written raw. Stringifying it
+    // here double-encodes the value: the SDK's cookie sync then parses it to a
+    // string rather than an object, reads `key`/`user_id` as undefined, treats
+    // every comparison as "changed", writes it back and refreshes the page —
+    // forever. Non-strings are still serialised so object callers keep working.
+    window.localStorage.setItem(
+      key,
+      typeof item === 'string' ? item : JSON.stringify(item),
+    );
   }
 
   async removeItem(key: string): Promise<void> {


### PR DESCRIPTION
## The bug

`LocalStorageService` was asymmetric — `getItem` read raw, `setItem` JSON-stringified:

```ts
async getItem<T>(key: string)          { return window.localStorage.getItem(key) as T; }
async setItem<T>(key: string, item: T) { window.localStorage.setItem(key, JSON.stringify(item)); }
```

So every **string** written through the SDK came back **double-encoded**.

That fed an infinite refresh loop in the SDK's `syncCookiesToLocalStorage`. From a console capture of a mentor embed on a different tenant — **120 iterations in 112 seconds**:

```
cookieCurrentTenant  {"key":"gillis",...}          ← JSON string
localCurrentTenant   "{\"key\":\"gillis\",...}"    ← JSON string of a JSON string
Cookie sync detected changes from another SPA, refreshing page
```

Identical values, reported as different, forever:

1. the tenant keys genuinely differ, so the sync writes the cookie value to storage
2. `setItem` stringifies that string → stored double-encoded
3. next poll, one `JSON.parse` yields the JSON *string*, not an object, so `.key` is `undefined`
4. `"gillis" !== undefined` → "changed" → write → refresh → **back to 2, forever**

It also fired 118 `interval redirecting to auth spa` attempts, stopped only by the login-timestamp guard.

## The fix

Strings are written as-is, so they round-trip through `getItem`. Non-strings are still serialised, so object callers are unaffected.

This matches how the other SPAs implement the same interface (mentorai, apps/auth both write raw).

## Verified

- `tsc --noEmit` clean
- full suite **3032 passed / 10 skipped**
- new case asserting a JSON string round-trips (`setItem` → `getItem` → `JSON.parse` gives the object back); the existing non-string case still asserts stringification

## Related

iblai/iblai-web-frontend#2059 hardens the SDK's comparison so no host adapter can spin this loop again, and fixes a second issue in the same capture where a tenant switch offered to the host was never taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)