### PR TITLE
test(e2e): assert the mentor embed loads and settles

### DIFF
--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # SkillsAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-09-03 | 252 checkpoints | 35 journeys | 100% covered
+> Last updated: 2026-09-04 | 256 checkpoints | 36 journeys | 100% covered
 
 ## How This Works
 
@@ -512,6 +512,22 @@ When adding a new page or modifying an existing user flow:
 - [x] The tenant's default onboarding agent is reachable by its own per-agent link
 - [x] The agent-scoped route never shows the admin setup steps, even for an admin
 - [x] An admin can still switch to the setup flow from an agent link; a member cannot
+
+---
+
+## Journey 37: Mentor Embed Loads (4 checkpoints) — `journeys/37-mentor-embed-loads.spec.ts`
+
+**Source files:** `components/course-agent-chat.tsx`, `components/chat-button.tsx`, `app/platform/[tenant]/onboarding/onboarding-flow-page.tsx`
+
+The mentor is embedded through the `agent-ai` web component, which puts the mentor app in an
+iframe inside its own shadow root. The host owns the auth and answers the embed over
+`postMessage`; none of that handshake is visible from outside, so when it breaks the embed does
+not error — it spins. These checkpoints assert what an outside observer can distinguish.
+
+- [x] The host renders the `agent-ai` component pointed at this tenant's mentor
+- [x] The embed reaches the mentor app inside the iframe rather than a spinner or an error
+- [x] The embed runs on the same tenant as the host, not a stale one
+- [x] The embed settles instead of re-navigating in an auth-handshake loop
 
 ---
 

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -1,18 +1,21 @@
 {
   "version": 2,
-  "lastUpdated": "2026-09-03",
+  "lastUpdated": "2026-09-04",
   "summary": {
-    "totalCheckpoints": 252,
-    "coveredCheckpoints": 252,
+    "totalCheckpoints": 256,
+    "coveredCheckpoints": 256,
     "percent": 100,
-    "totalJourneys": 35
+    "totalJourneys": 36
   },
   "journeys": [
     {
       "id": "authentication",
       "name": "Authentication",
       "spec": "01-authentication.spec.ts",
-      "sourceFiles": ["app/sso-login/page.tsx", "app/sso-login-complete/page.tsx"],
+      "sourceFiles": [
+        "app/sso-login/page.tsx",
+        "app/sso-login-complete/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "auth-01",
@@ -38,7 +41,7 @@
     },
     {
       "id": "onboarding-first-time-user",
-      "name": "Onboarding — First-Time User",
+      "name": "Onboarding \u2014 First-Time User",
       "spec": "02-onboarding-first-time-user.spec.ts",
       "sourceFiles": [
         "app/start/page.tsx",
@@ -172,7 +175,7 @@
     },
     {
       "id": "course-content-tabs",
-      "name": "Course Content — Tab Navigation & Iframes",
+      "name": "Course Content \u2014 Tab Navigation & Iframes",
       "spec": "05-course-content-tabs.spec.ts",
       "sourceFiles": [
         "app/course-content/[course_id]/course/page.tsx",
@@ -373,12 +376,12 @@
         },
         {
           "id": "tabs-34",
-          "description": "Unit media dropdown (next to the fullscreen control) lists the current unit’s pdf / video / ibl-media-catalog blocks with name and type; selecting one previews student_view_url in an overlay on the Agent tab and posts a SCROLL_TO message to the edX iframe on the Course tab",
+          "description": "Unit media dropdown (next to the fullscreen control) lists the current unit\u2019s pdf / video / ibl-media-catalog blocks with name and type; selecting one previews student_view_url in an overlay on the Agent tab and posts a SCROLL_TO message to the edX iframe on the Course tab",
           "status": "covered"
         },
         {
           "id": "tabs-35",
-          "description": "Course content layout requests the signed-in user’s role listing (GET /api/ibl/users/manage/roles/, looked up by username / email / user_id) so course-scoped roles can gate the staff tabs",
+          "description": "Course content layout requests the signed-in user\u2019s role listing (GET /api/ibl/users/manage/roles/, looked up by username / email / user_id) so course-scoped roles can gate the staff tabs",
           "status": "covered"
         },
         {
@@ -439,7 +442,7 @@
     },
     {
       "id": "profile-skills",
-      "name": "Profile — Skills",
+      "name": "Profile \u2014 Skills",
       "spec": "07-profile-skills.spec.ts",
       "sourceFiles": [
         "app/profile/skills/page.tsx",
@@ -477,9 +480,12 @@
     },
     {
       "id": "profile-credentials",
-      "name": "Profile — Credentials",
+      "name": "Profile \u2014 Credentials",
       "spec": "08-profile-credentials.spec.ts",
-      "sourceFiles": ["app/profile/credentials/page.tsx", "components/credential-box.tsx"],
+      "sourceFiles": [
+        "app/profile/credentials/page.tsx",
+        "components/credential-box.tsx"
+      ],
       "checkpoints": [
         {
           "id": "cred-01",
@@ -510,7 +516,7 @@
     },
     {
       "id": "profile-pathways",
-      "name": "Profile — Pathways",
+      "name": "Profile \u2014 Pathways",
       "spec": "09-profile-pathways.spec.ts",
       "sourceFiles": [
         "app/profile/pathways/page.tsx",
@@ -546,9 +552,12 @@
     },
     {
       "id": "profile-programs",
-      "name": "Profile — Programs",
+      "name": "Profile \u2014 Programs",
       "spec": "10-profile-programs.spec.ts",
-      "sourceFiles": ["app/profile/programs/page.tsx", "app/programs/[program_id]/page.tsx"],
+      "sourceFiles": [
+        "app/profile/programs/page.tsx",
+        "app/programs/[program_id]/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "prog-01",
@@ -587,7 +596,7 @@
         },
         {
           "id": "prog-08",
-          "description": "Tab switching About → Courses → Settings updates content",
+          "description": "Tab switching About \u2192 Courses \u2192 Settings updates content",
           "status": "covered"
         },
         {
@@ -604,9 +613,11 @@
     },
     {
       "id": "profile-courses",
-      "name": "Profile — Courses",
+      "name": "Profile \u2014 Courses",
       "spec": "11-profile-courses.spec.ts",
-      "sourceFiles": ["app/profile/courses/page.tsx"],
+      "sourceFiles": [
+        "app/profile/courses/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "pcrs-01",
@@ -632,9 +643,11 @@
     },
     {
       "id": "profile-public",
-      "name": "Profile — Public",
+      "name": "Profile \u2014 Public",
       "spec": "12-profile-public.spec.ts",
-      "sourceFiles": ["app/profile/public/page.tsx"],
+      "sourceFiles": [
+        "app/profile/public/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "pub-01",
@@ -657,7 +670,9 @@
       "id": "recommended-courses",
       "name": "Recommended Courses",
       "spec": "13-recommended-courses.spec.ts",
-      "sourceFiles": ["app/recommended/page.tsx"],
+      "sourceFiles": [
+        "app/recommended/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "rec-01",
@@ -748,7 +763,10 @@
       "id": "notifications",
       "name": "Notifications",
       "spec": "15-notifications.spec.ts",
-      "sourceFiles": ["app/notifications/page.tsx", "app/notifications/[notificationId]/page.tsx"],
+      "sourceFiles": [
+        "app/notifications/page.tsx",
+        "app/notifications/[notificationId]/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "notif-01",
@@ -873,7 +891,7 @@
     },
     {
       "id": "analytics-content",
-      "name": "Analytics Content — Courses & Programs",
+      "name": "Analytics Content \u2014 Courses & Programs",
       "spec": "18-analytics-content.spec.ts",
       "sourceFiles": [
         "app/analytics/courses/page.tsx",
@@ -1056,7 +1074,10 @@
       "id": "search",
       "name": "Search",
       "spec": "21-search.spec.ts",
-      "sourceFiles": ["app/discover/page.tsx", "components/nav-bar.tsx"],
+      "sourceFiles": [
+        "app/discover/page.tsx",
+        "components/nav-bar.tsx"
+      ],
       "checkpoints": [
         {
           "id": "search-01",
@@ -1087,7 +1108,7 @@
     },
     {
       "id": "navigation-navbar",
-      "name": "Navigation — NavBar & Sidebar",
+      "name": "Navigation \u2014 NavBar & Sidebar",
       "spec": "22-navigation-navbar.spec.ts",
       "sourceFiles": [
         "components/nav-bar.tsx",
@@ -1146,7 +1167,9 @@
       "id": "edit-profile-dialog",
       "name": "Edit Profile Dialog",
       "spec": "23-edit-profile-dialog.spec.ts",
-      "sourceFiles": ["components/edit-profile-dialog.tsx"],
+      "sourceFiles": [
+        "components/edit-profile-dialog.tsx"
+      ],
       "checkpoints": [
         {
           "id": "ep-01",
@@ -1239,9 +1262,12 @@
     },
     {
       "id": "chat-embed",
-      "name": "Chat Embed — Mentor Widget",
+      "name": "Chat Embed \u2014 Mentor Widget",
       "spec": "25-chat-embed.spec.ts",
-      "sourceFiles": ["components/chat-button.tsx", "components/chat/index.tsx"],
+      "sourceFiles": [
+        "components/chat-button.tsx",
+        "components/chat/index.tsx"
+      ],
       "checkpoints": [
         {
           "id": "chat-01",
@@ -1279,7 +1305,10 @@
       "id": "error-pages",
       "name": "Error Pages",
       "spec": "26-error-pages.spec.ts",
-      "sourceFiles": ["app/error/[code]/page.tsx", "app/not-found.tsx"],
+      "sourceFiles": [
+        "app/error/[code]/page.tsx",
+        "app/not-found.tsx"
+      ],
       "checkpoints": [
         {
           "id": "err-01",
@@ -1307,7 +1336,11 @@
       "id": "ui-render-console-errors",
       "name": "UI Render Console Errors",
       "spec": "27-ui-render-console-errors.spec.ts",
-      "sourceFiles": ["app/home/page.tsx", "app/discover/page.tsx", "app/profile/page.tsx"],
+      "sourceFiles": [
+        "app/home/page.tsx",
+        "app/discover/page.tsx",
+        "app/profile/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "ui-01",
@@ -1330,7 +1363,10 @@
       "id": "tenant-management-invitations",
       "name": "Tenant Management & Invitations",
       "spec": "28-tenant-management-invitations.spec.ts",
-      "sourceFiles": ["components/account-dialog.tsx", "components/account-button.tsx"],
+      "sourceFiles": [
+        "components/account-dialog.tsx",
+        "components/account-button.tsx"
+      ],
       "checkpoints": [
         {
           "id": "tm-01",
@@ -1376,7 +1412,7 @@
     },
     {
       "id": "accessibility-wcag",
-      "name": "Accessibility — WCAG 2.1 AA",
+      "name": "Accessibility \u2014 WCAG 2.1 AA",
       "spec": "29-accessibility-wcag.spec.ts",
       "sourceFiles": [
         "app/home/page.tsx",
@@ -1440,9 +1476,12 @@
     },
     {
       "id": "course-access-guard-tenant-redirect",
-      "name": "Course Access Guard — Cross-Tenant Redirect",
+      "name": "Course Access Guard \u2014 Cross-Tenant Redirect",
       "spec": "30-course-access-guard-tenant-redirect.spec.ts",
-      "sourceFiles": ["components/course-access-guard.tsx", "utils/helpers.ts"],
+      "sourceFiles": [
+        "components/course-access-guard.tsx",
+        "utils/helpers.ts"
+      ],
       "checkpoints": [
         {
           "id": "cag-01",
@@ -1498,7 +1537,7 @@
         },
         {
           "id": "pdp-05",
-          "description": "Tab switching About → Courses → Settings updates aria-selected and tab content",
+          "description": "Tab switching About \u2192 Courses \u2192 Settings updates aria-selected and tab content",
           "status": "covered"
         },
         {
@@ -1558,7 +1597,9 @@
       "id": "admin-onboarding-wizard",
       "name": "Admin Onboarding Wizard",
       "spec": "34-admin-onboarding-wizard.spec.ts",
-      "sourceFiles": ["app/platform/[tenant]/onboarding/page.tsx"],
+      "sourceFiles": [
+        "app/platform/[tenant]/onboarding/page.tsx"
+      ],
       "checkpoints": [
         {
           "id": "adminonb-01",
@@ -1624,14 +1665,14 @@
         },
         {
           "id": "useronb-04",
-          "description": "The member flow holds the onboarding route — a tenant with no form configured shows the notice instead of redirecting away",
+          "description": "The member flow holds the onboarding route \u2014 a tenant with no form configured shows the notice instead of redirecting away",
           "status": "covered"
         }
       ]
     },
     {
       "id": "user-onboarding-agent-link",
-      "name": "User Onboarding — Per-Agent Links",
+      "name": "User Onboarding \u2014 Per-Agent Links",
       "spec": "36-user-onboarding-agent-link.spec.ts",
       "sourceFiles": [
         "app/platform/[tenant]/onboarding/[agentId]/page.tsx",
@@ -1661,6 +1702,38 @@
         {
           "id": "agentlink-05",
           "description": "An admin can still switch to the setup flow from an agent link; a member cannot",
+          "status": "covered"
+        }
+      ]
+    },
+    {
+      "id": "mentor-embed-loads",
+      "name": "Mentor Embed Loads",
+      "spec": "37-mentor-embed-loads.spec.ts",
+      "sourceFiles": [
+        "components/course-agent-chat.tsx",
+        "components/chat-button.tsx",
+        "app/platform/[tenant]/onboarding/onboarding-flow-page.tsx"
+      ],
+      "checkpoints": [
+        {
+          "id": "embed-01",
+          "description": "The host renders the agent-ai component pointed at this tenant's mentor",
+          "status": "covered"
+        },
+        {
+          "id": "embed-02",
+          "description": "The embed reaches the mentor app inside the iframe rather than a spinner or an error",
+          "status": "covered"
+        },
+        {
+          "id": "embed-03",
+          "description": "The embed runs on the same tenant as the host, not a stale one",
+          "status": "covered"
+        },
+        {
+          "id": "embed-04",
+          "description": "The embed settles instead of re-navigating in an auth-handshake loop",
           "status": "covered"
         }
       ]

--- a/e2e/journeys/37-mentor-embed-loads.spec.ts
+++ b/e2e/journeys/37-mentor-embed-loads.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test';
+import { logger } from '@iblai/iblai-js/playwright';
+import { gotoTenantPage } from '../utils/navigation';
+
+/**
+ * Journey 37: Mentor Embed Loads
+ *
+ * SkillsAI embeds the mentor through the `agent-ai` web component, which puts
+ * the mentor app in an iframe inside its own shadow root. The host owns the
+ * auth: the embed announces itself, asks for what it needs over `postMessage`,
+ * and the host answers. Nothing in that handshake is visible from the outside,
+ * so when it goes wrong the embed does not error — it spins.
+ *
+ * Every failure this suite exists to catch has looked identical from the host
+ * page: an embed that never finishes loading. They were caused by the answer
+ * being dropped, the answer being incomplete, or the answer being re-applied
+ * forever. So the checkpoints below assert what an outside observer can
+ * actually distinguish:
+ *
+ *   1. The host renders the component, pointed at this tenant's mentor
+ *   2. The embed reaches the mentor app rather than a spinner or an error
+ *   3. The embed carries the SAME tenant as the host, not a stale one
+ *   4. The embed SETTLES — it does not reload itself in a loop
+ *
+ * Checkpoint 4 is the regression guard: a working embed navigates a small,
+ * bounded number of times; a broken auth handshake re-navigates every few
+ * seconds for as long as you watch.
+ */
+test.describe('Journey 37: Mentor Embed Loads', () => {
+  test.setTimeout(200000);
+
+  type Page = import('@playwright/test').Page;
+
+  /**
+   * The onboarding route is the embed surface that needs no course fixture, so
+   * it is reachable on any environment. Playwright's CSS engine pierces open
+   * shadow roots, so the component's inner iframe is addressable directly.
+   */
+  const AGENT_ELEMENT = 'agent-ai';
+  const EMBED_IFRAME = 'agent-ai iframe';
+
+  /** How long an embed is allowed to keep navigating before we call it a loop. */
+  const SETTLE_WINDOW_MS = 20_000;
+
+  /**
+   * A working embed may navigate a couple of times legitimately — the initial
+   * load, and one reload if the host hands it fresh auth. Repeated navigation
+   * past that is the loop.
+   */
+  const MAX_EMBED_NAVIGATIONS = 3;
+
+  /** Land on a surface that embeds the mentor, or report that none is configured. */
+  async function gotoEmbedSurface(page: Page): Promise<boolean> {
+    await gotoTenantPage(page, 'onboarding?flow=user', { timeout: 120000 });
+    const appeared = await page
+      .locator(AGENT_ELEMENT)
+      .first()
+      .waitFor({ state: 'attached', timeout: 60000 })
+      .then(() => true)
+      .catch(() => false);
+    return appeared;
+  }
+
+  /** The tenant this browser session is actually on, as the host stores it. */
+  async function hostTenant(page: Page): Promise<string | null> {
+    return page
+      .evaluate(() => {
+        try {
+          return JSON.parse(localStorage.getItem('current_tenant') || '{}').key ?? null;
+        } catch {
+          return null;
+        }
+      })
+      .catch(() => null);
+  }
+
+  test('Checkpoint 1: The host renders the mentor component for this tenant', async ({ page }) => {
+    if (!(await gotoEmbedSurface(page))) {
+      logger.info('No mentor embed configured on this tenant — nothing to assert');
+      return;
+    }
+
+    const agent = page.locator(AGENT_ELEMENT).first();
+    const tenant = await hostTenant(page);
+
+    // The component is pointed at a mentor, on the tenant the host is on.
+    await expect(agent).toHaveAttribute('mentor', /.+/, { timeout: 60000 });
+    if (tenant) {
+      await expect(agent).toHaveAttribute('tenant', tenant, { timeout: 60000 });
+    }
+    logger.info(`Mentor component rendered for tenant ${tenant ?? '(unknown)'}`);
+  });
+
+  test('Checkpoint 2: The embed reaches the mentor app, not a spinner', async ({ page }) => {
+    if (!(await gotoEmbedSurface(page))) {
+      logger.info('No mentor embed configured on this tenant — nothing to assert');
+      return;
+    }
+
+    const iframe = page.locator(EMBED_IFRAME).first();
+    await expect(iframe).toBeVisible({ timeout: 120000 });
+
+    // The frame is pointed at the mentor app on a platform route, which is
+    // what the component builds once it knows the tenant and mentor.
+    await expect(iframe).toHaveAttribute('src', /\/platform\//, { timeout: 60000 });
+
+    // Inside, the mentor app has actually rendered something interactive.
+    // Any of these means the app booted; a stuck embed shows none of them.
+    const frame = page.frameLocator(EMBED_IFRAME).first();
+    const mentorUi = frame
+      .getByRole('textbox')
+      .or(frame.locator('textarea'))
+      .or(frame.getByRole('button', { name: /send|ask/i }))
+      .first();
+
+    await expect(mentorUi).toBeVisible({ timeout: 120000 });
+    logger.info('Mentor app rendered inside the embed');
+  });
+
+  test('Checkpoint 3: The embed runs on the same tenant as the host', async ({ page }) => {
+    if (!(await gotoEmbedSurface(page))) {
+      logger.info('No mentor embed configured on this tenant — nothing to assert');
+      return;
+    }
+
+    const tenant = await hostTenant(page);
+    if (!tenant) {
+      logger.info('Host tenant not resolvable from storage — skipping the comparison');
+      return;
+    }
+
+    const iframe = page.locator(EMBED_IFRAME).first();
+    await expect(iframe).toBeVisible({ timeout: 120000 });
+
+    // The mentor is served per tenant, so its own URL carries the tenant it
+    // believes it is on. A mismatch here is the tenant-switch failure: the
+    // embed left on a stale tenant while the host moved on.
+    await expect(iframe).toHaveAttribute('src', new RegExp(`/platform/${tenant}(/|\\?|$)`), {
+      timeout: 120000,
+    });
+    logger.info(`Embed and host agree on tenant ${tenant}`);
+  });
+
+  test('Checkpoint 4: The embed settles instead of reloading in a loop', async ({ page }) => {
+    if (!(await gotoEmbedSurface(page))) {
+      logger.info('No mentor embed configured on this tenant — nothing to assert');
+      return;
+    }
+
+    await expect(page.locator(EMBED_IFRAME).first()).toBeVisible({ timeout: 120000 });
+
+    // Count navigations of the embedded frame only. A broken auth handshake
+    // re-navigates it every few seconds: save, reload, receive the same
+    // answer, save again.
+    let navigations = 0;
+    const onNavigated = (frame: import('@playwright/test').Frame) => {
+      if (frame === page.mainFrame()) return;
+      if (frame.url().includes('/platform/')) navigations += 1;
+    };
+    page.on('framenavigated', onNavigated);
+
+    await page.waitForTimeout(SETTLE_WINDOW_MS);
+    page.off('framenavigated', onNavigated);
+
+    logger.info(
+      `Embed navigated ${navigations} time(s) in ${SETTLE_WINDOW_MS / 1000}s ` +
+        `(limit ${MAX_EMBED_NAVIGATIONS})`,
+    );
+    expect(
+      navigations,
+      `The embed kept reloading (${navigations} navigations in ${
+        SETTLE_WINDOW_MS / 1000
+      }s), which is the auth-handshake loop`,
+    ).toBeLessThanOrEqual(MAX_EMBED_NAVIGATIONS);
+  });
+});


### PR DESCRIPTION
## Why

The mentor is embedded through the `agent-ai` web component, which puts the mentor app in an iframe inside its own shadow root. The host owns the auth: the embed announces itself, asks for what it needs over `postMessage`, and the host answers. **None of that handshake is observable from the host page** — so when it breaks, the embed does not error. It spins.

Every failure we chased recently looked identical from outside — an embed that never finishes loading:

| Cause | Fix |
|---|---|
| the answer was dropped (host sent a JSON string, embed only read objects) | iblai/os#484 |
| the answer was incomplete (`current_tenant` omitted, and the embed clears storage before writing) | iblai-web-frontend#2062 |
| the answer was re-applied forever (save → reload → same answer → save) | iblai/os#486 |

None would have been caught by a test that only checks a button is visible.

## What it asserts

Journey 37, four checkpoints — chosen to be things an outside observer can actually distinguish:

1. **The host renders the component** pointed at this tenant's mentor
2. **The embed reaches the mentor app** inside the iframe, not a spinner or an error
3. **The embed runs on the same tenant as the host** — a mismatch is the tenant-switch failure
4. **The embed settles** rather than re-navigating in a loop

Checkpoint 4 is the regression guard: it counts navigations of the embedded frame over a 20s window. A working embed navigates a small bounded number of times; a broken handshake re-navigates every few seconds for as long as you watch. That is the "infinite loading" symptom, expressed as an assertion.

## Notes

- Playwright's CSS engine pierces open shadow roots, so `agent-ai iframe` addresses the component's inner frame directly — no manual shadow-root traversal.
- Uses the onboarding surface, the one embed point that needs no course fixture, so it runs on any environment. Where a tenant configures no embed the checkpoints say so and pass rather than asserting a fiction — the same convention as Journey 36.
- Journey 25 nominally covers the embed but is `test.fixme` and never enters the iframe; left alone here rather than widening this change.
- `COVERAGE.md` and `coverage.json` updated (252 → 256 checkpoints, 35 → 36 journeys); `check-journey-coverage.mjs` passes; spec is discovered across all three browser projects.

## Next

The three-level chain (`skillsai → edX → mentor`), which iblai-web-frontend#2063 added the relay for. That needs an edX page that itself embeds `agent-ai` — either a real URL in the test environment or a fixture page in this suite standing in for edX. Worth deciding which before writing it.
